### PR TITLE
0.19.9

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -28,6 +28,7 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-16">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/build_pack_all.bat
+++ b/build_pack_all.bat
@@ -2,5 +2,5 @@
 call "set version.bat"
 call "build_pack_windows.bat"
 call "build_pack_linux.bat"
-::call "build_pack_mac.bat"
-::call "build_pack_mac_arm.bat"
+call "build_pack_mac.bat"
+call "build_pack_mac_arm.bat"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>log.program</groupId>
 	<artifactId>Charter</artifactId>
-	<version>0.19.8</version>
+	<version>0.19.9</version>
 	<packaging>jar</packaging>
 	<name>Charter</name>
 	<description>Charting program for guitar</description>

--- a/src/main/java/com/breakfastquay/rubberband/RubberBandStretcher.java
+++ b/src/main/java/com/breakfastquay/rubberband/RubberBandStretcher.java
@@ -26,6 +26,8 @@ package com.breakfastquay.rubberband;
 import java.util.Map;
 import java.util.Set;
 
+import log.charter.io.Logger;
+
 public class RubberBandStretcher {
 	public RubberBandStretcher(final int sampleRate, final int channels, final int options,
 			final double initialTimeRatio, final double initialPitchScale) {
@@ -156,7 +158,15 @@ public class RubberBandStretcher {
 	public static final int DefaultOptions = 0x00000000;
 	public static final int PercussiveOptions = 0x00102000;
 
-	static {
-		System.loadLibrary("rubberband-jni");
+	private static boolean loadLibrary() {
+		try {
+			System.loadLibrary("rubberband-jni");
+			return true;
+		} catch (final Throwable t) {
+			Logger.error("Couldn't load rubberband library", t);
+			return false;
+		}
 	}
+
+	public static final boolean loaded = loadLibrary();
 };

--- a/src/main/java/log/charter/CharterMain.java
+++ b/src/main/java/log/charter/CharterMain.java
@@ -10,7 +10,7 @@ import log.charter.services.mouseAndKeyboard.ShortcutConfig;
 
 public class CharterMain {
 	public static final String VERSION = "0.19.9";
-	public static final String VERSION_DATE = "2025.02.06 20:00";
+	public static final String VERSION_DATE = "2025.02.06 23:00";
 	public static final String TITLE = "Charter " + VERSION;
 
 	public static void main(final String[] args) throws InterruptedException, IOException {

--- a/src/main/java/log/charter/CharterMain.java
+++ b/src/main/java/log/charter/CharterMain.java
@@ -9,27 +9,31 @@ import log.charter.services.CharterContext;
 import log.charter.services.mouseAndKeyboard.ShortcutConfig;
 
 public class CharterMain {
-	public static final String VERSION = "0.19.8";
-	public static final String VERSION_DATE = "2025.02.02 17:00";
+	public static final String VERSION = "0.19.9";
+	public static final String VERSION_DATE = "2025.02.06 20:00";
 	public static final String TITLE = "Charter " + VERSION;
 
 	public static void main(final String[] args) throws InterruptedException, IOException {
-		Config.init();
-		GraphicalConfig.init();
-		ShortcutConfig.init();
+		try {
+			Config.init();
+			GraphicalConfig.init();
+			ShortcutConfig.init();
 
-		String pathToOpen = Config.lastPath;
-		if (args.length > 0) {
-			pathToOpen = args[0];
+			String pathToOpen = Config.lastPath;
+			if (args.length > 0) {
+				pathToOpen = args[0];
+			}
+
+			final CharterContext context = new CharterContext();
+			context.init();
+
+			if (pathToOpen != null && !pathToOpen.isEmpty()) {
+				context.openProject(pathToOpen);
+			}
+
+			Logger.info("Charter started");
+		} catch (final Throwable t) {
+			Logger.error("Couldn't start Charter", t);
 		}
-
-		final CharterContext context = new CharterContext();
-		context.init();
-
-		if (pathToOpen != null && !pathToOpen.isEmpty()) {
-			context.openProject(pathToOpen);
-		}
-
-		Logger.info("Charter started");
 	}
 }

--- a/src/main/java/log/charter/data/config/Config.java
+++ b/src/main/java/log/charter/data/config/Config.java
@@ -182,9 +182,6 @@ public class Config {
 
 		passFilters.installValueAccessors(valueAccessors, "passFilters");
 
-		final String os = System.getProperty("os.name").toLowerCase();
-		@SuppressWarnings("unused")
-		final String osType = os.startsWith("windows") ? "windows" : os.startsWith("mac") ? "mac" : "linux";
 		oggEncPath = new File(RW.getProgramDirectory(), "oggenc" + File.separator + "oggenc2.exe").getAbsolutePath();
 
 		final GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();

--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -27,15 +27,20 @@ public class Localization {
 		ANCHOR_PANE("Anchor"), //
 		ANCHOR_WIDTH("Anchor width"), //
 		ARPEGGIO("Arpeggio"), //
+		ARRANGEMENT_ID_NAME("Arrangement %d, %s:"), //
+		ARRANGEMENT_IMPORT_OPTIONS("Arrangement import options"), //
 		ARRANGEMENT_MENU("Arrangement"), //
 		ARRANGEMENT_MENU_TEMPO_MAP("Tempo map"), //
 		ARRANGEMENT_MENU_VOCALS("Vocals"), //
 		ARRANGEMENT_NEXT("Next arrangement"), //
 		ARRANGEMENT_PREVIOUS("Previous arrangement"), //
 		ARRANGEMENT_OPTIONS("Arrangement options"), //
+		ARRANGEMENT_SKIP_ARRANGEMENT("Skip arrangement"), //
 		ARRANGEMENT_SUBTYPE_ALTERNATE("Alternate"), //
 		ARRANGEMENT_SUBTYPE_BONUS("Bonus"), //
 		ARRANGEMENT_SUBTYPE_MAIN("Main"), //
+		ARRANGEMENT_TO_EXISTING_ARRANGEMENT("To arrangement %d, %s"), //
+		ARRANGEMENT_TO_NEW_ARRANGEMENT("To new arrangement"), //
 		ARRANGEMENT_TYPE_BASS("Bass"), //
 		ARRANGEMENT_TYPE_COMBO("Combo"), //
 		ARRANGEMENT_TYPE_LEAD("Lead"), //
@@ -151,6 +156,37 @@ public class Localization {
 		PASTE("Paste"), //
 		PITCH_MUST_BE_POSITIVE("Pitch must be positive"), //
 		REDO("Redo"), //
+		SECTION_AMBIENT("Ambient"), //
+		SECTION_BREAKDOWN("Breakdown"), //
+		SECTION_BRIDGE("Bridge"), //
+		SECTION_BUILDUP("Buildup"), //
+		SECTION_CHORUS("Chorus"), //
+		SECTION_FADE_IN("Fade in"), //
+		SECTION_FADE_OUT("Fade out"), //
+		SECTION_HEAD("Head"), //
+		SECTION_HOOK("Hook"), //
+		SECTION_INTERLUDE("Interlude"), //
+		SECTION_INTRO("Intro"), //
+		SECTION_MELODY("Melody"), //
+		SECTION_MODULATED_BRIDGE("Modulated bridge"), //
+		SECTINO_MODULATED_CHORUS("Modulated chorus"), //
+		SECTION_MODULATED_VERSE("Modulated verse"), //
+		SECTION_NO_GUITAR("No guitar"), //
+		SECTION_OUTRO("Outro"), //
+		SECTION_POST_BRIDGE("Post bridge"), //
+		SECTION_POST_CHORUS("Post chorus"), //
+		SECTION_POST_VERSE("Post verse"), //
+		SECTION_PRE_BRIDGE("Pre bridge"), //
+		SECTION_PRE_CHORUS("Pre chorus"), //
+		SECTION_PRE_VERSE("Pre verse"), //
+		SECTION_RIFF("Riff"), //
+		SECTION_SILENCE("Silence"), //
+		SECITON_SOLO("Solo"), //
+		SECTION_TAPPING("Tapping"), //
+		SECTION_TRANSITION("Transition"), //
+		SECTION_VAMP("Vamp"), //
+		SECTION_VARIATION("Variation"), //
+		SECTION_VERSE("Verse"), //
 		SECTION_WITHOUT_PHRASE("Section without phrase"), //
 		SELECT_ALL_NOTES("Select all notes"), //
 		SELECT_NOTES_BY_TAILS("Select notes by tails"), //
@@ -265,13 +301,6 @@ public class Localization {
 		GUITAR_MENU_AUTOCREATE_FHP("Autocreate Fret Hand Positions"), //
 		TOGGLE_PREVIEW_WINDOW("Windowed preview"), //
 		TOGGLE_BORDERLESS_PREVIEW_WINDOW("Borderless windowed preview"), //
-
-		GP_IMPORT_OPTIONS("Guitar Pro file import options"), //
-		GP5_IMPORT_BEAT_MAP_CHANGE("Import beat map"), //
-		GP_IMPORT_ARRANGEMENT_NAME("Arrangement %d, %s:"), //
-		GP_IMPORT_SKIP_ARRANGEMENT("Skip arrangement"), //
-		GP_IMPORT_TO_NEW_ARRANGEMENT("To new arrangement"), //
-		GP_IMPORT_TO_EXISTING_ARRANGEMENT("To arrangement %d, %s"), //
 
 		TEMPO_BEAT_PANE("Tempo beat options"), //
 		TEMPO_BEAT_PANE_BPM("BPM"), //

--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -56,6 +56,7 @@ public class Localization {
 		BUFFER_SIZE_MS("Audio buffer size to fill (ms)"), //
 		BUTTON_CANCEL("Cancel"), //
 		BUTTON_SAVE("Save"), //
+		CANT_DROP_WITHOUT_PROJECT("Can't import file without project open"), //
 		CENTS("%s cents"), //
 		CHANGE_AUDIO("Change audio"), //
 		CHOOSE_COLOR_FOR("Choose color for %s"), //
@@ -101,6 +102,7 @@ public class Localization {
 		FRET_7("Fret 7"), //
 		FRET_8("Fret 8"), //
 		FRET_9("Fret 9"), //
+		GO_PLAY_ALONG("GoPlayAlong file"), //
 		GUITAR_ARRANGEMENT("Guitar arrangement"), //
 		HIGH_PASS("High"), //
 		HIGH_PASS_SETTINGS("High pass settings"), //
@@ -169,7 +171,7 @@ public class Localization {
 		SECTION_INTRO("Intro"), //
 		SECTION_MELODY("Melody"), //
 		SECTION_MODULATED_BRIDGE("Modulated bridge"), //
-		SECTINO_MODULATED_CHORUS("Modulated chorus"), //
+		SECTION_MODULATED_CHORUS("Modulated chorus"), //
 		SECTION_MODULATED_VERSE("Modulated verse"), //
 		SECTION_NO_GUITAR("No guitar"), //
 		SECTION_OUTRO("Outro"), //
@@ -181,7 +183,7 @@ public class Localization {
 		SECTION_PRE_VERSE("Pre verse"), //
 		SECTION_RIFF("Riff"), //
 		SECTION_SILENCE("Silence"), //
-		SECITON_SOLO("Solo"), //
+		SECTION_SOLO("Solo"), //
 		SECTION_TAPPING("Tapping"), //
 		SECTION_TRANSITION("Transition"), //
 		SECTION_VAMP("Vamp"), //

--- a/src/main/java/log/charter/data/config/SystemType.java
+++ b/src/main/java/log/charter/data/config/SystemType.java
@@ -1,0 +1,28 @@
+package log.charter.data.config;
+
+public enum SystemType {
+	LINUX, MAC, WINDOWS, OTHER;
+
+	public static final SystemType systemType = MAC;
+
+	private static SystemType findSystemType() {
+		final String os = System.getProperty("os.name").toLowerCase();
+		return os.startsWith("windows") ? WINDOWS//
+				: os.startsWith("mac") ? MAC//
+						: LINUX;
+	}
+
+	public static boolean is(final SystemType... types) {
+		for (final SystemType type : types) {
+			if (systemType == type) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static boolean not(final SystemType... types) {
+		return !is(types);
+	}
+}

--- a/src/main/java/log/charter/data/config/Theme.java
+++ b/src/main/java/log/charter/data/config/Theme.java
@@ -1,8 +1,15 @@
 package log.charter.data.config;
 
-public enum Theme {
-	BASIC, //
-	SQUARE, //
-	MODERN;
+import log.charter.data.config.Localization.Label;
 
+public enum Theme {
+	BASIC(Label.THEME_BASIC), //
+	SQUARE(Label.THEME_SQUARE), //
+	MODERN(Label.THEME_MODERN);
+
+	public final Label label;
+
+	private Theme(final Label label) {
+		this.label = label;
+	}
 }

--- a/src/main/java/log/charter/data/song/SectionType.java
+++ b/src/main/java/log/charter/data/song/SectionType.java
@@ -1,43 +1,45 @@
 package log.charter.data.song;
 
+import log.charter.data.config.Localization.Label;
+
 public enum SectionType {
-	NO_GUITAR("noguitar", "No guitar"), //
-	INTRO("intro", "Intro"), //
-	PRE_VERSE("preverse", "Pre verse"), //
-	VERSE("verse", "Verse"), //
-	POST_VERSE("postvs", "Post verse"), //
-	MODULATED_VERSE("modverse", "Modulated verse"), //
-	PRE_CHORUS("prechorus", "Pre chorus"), //
-	CHORUS("chorus", "Chorus"), //
-	POST_CHORUS("postchorus", "Post chorus"), //
-	MODULATED_CHORUS("modchorus", "Modulated chorus"), //
-	HOOK("hook", "Hook"), //
-	PRE_BRIDGE("prebrdg", "Pre bridge"), //
-	BRIDGE("bridge", "Bridge"), //
-	POST_BRIDGE("postbrdg", "Post bridge"), //
-	SOLO("solo", "Solo"), //
-	OUTRO("outro", "Outro"), //
-	AMBIENT("ambient", "Ambient"), //
-	BREAKDOWN("breakdown", "Breakdown"), //
-	INTERLUDE("interlude", "Interlude"), //
-	TRANSITION("transition", "Transition"), //
-	RIFF("riff", "Riff"), //
-	FADE_IN("fadein", "Fade in"), //
-	FADE_OUT("fadeout", "Fade out"), //
-	BUILDUP("buildup", "Buildup"), //
-	VARIATION("variation", "Variation"), //
-	HEAD("head", "Head"), //
-	MODULATED_BRIDGE("modbridge", "Modulated bridge"), //
-	MELODY("melody", "Melody"), //
-	VAMP("vamp", "Vamp"), //
-	SILENCE("silence", "Silence"), //
-	TAPPING("tapping", "Tapping");
+	NO_GUITAR("noguitar"), //
+	INTRO("intro"), //
+	PRE_VERSE("preverse"), //
+	VERSE("verse"), //
+	POST_VERSE("postvs"), //
+	MODULATED_VERSE("modverse"), //
+	PRE_CHORUS("prechorus"), //
+	CHORUS("chorus"), //
+	POST_CHORUS("postchorus"), //
+	MODULATED_CHORUS("modchorus"), //
+	HOOK("hook"), //
+	PRE_BRIDGE("prebrdg"), //
+	BRIDGE("bridge"), //
+	POST_BRIDGE("postbrdg"), //
+	SOLO("solo"), //
+	OUTRO("outro"), //
+	AMBIENT("ambient"), //
+	BREAKDOWN("breakdown"), //
+	INTERLUDE("interlude"), //
+	TRANSITION("transition"), //
+	RIFF("riff"), //
+	FADE_IN("fadein"), //
+	FADE_OUT("fadeout"), //
+	BUILDUP("buildup"), //
+	VARIATION("variation"), //
+	HEAD("head"), //
+	MODULATED_BRIDGE("modbridge"), //
+	MELODY("melody"), //
+	VAMP("vamp"), //
+	SILENCE("silence"), //
+	TAPPING("tapping");
 
 	public final String rsName;
-	public final String label;
+	public final Label label;
 
-	private SectionType(final String rsName, final String label) {
+	private SectionType(final String rsName) {
 		this.rsName = rsName;
-		this.label = label;
+		label = Label.valueOf("SECTION_" + name());
 	}
 }

--- a/src/main/java/log/charter/data/song/SectionType.java
+++ b/src/main/java/log/charter/data/song/SectionType.java
@@ -40,6 +40,11 @@ public enum SectionType {
 
 	private SectionType(final String rsName) {
 		this.rsName = rsName;
-		label = Label.valueOf("SECTION_" + name());
+		try {
+			label = Label.valueOf("SECTION_" + name());
+		} catch (final Throwable t) {
+			t.printStackTrace();
+			throw t;
+		}
 	}
 }

--- a/src/main/java/log/charter/gui/CharterFrame.java
+++ b/src/main/java/log/charter/gui/CharterFrame.java
@@ -1,6 +1,7 @@
 package log.charter.gui;
 
 import static java.util.Arrays.asList;
+import static log.charter.data.config.SystemType.MAC;
 
 import java.awt.Component;
 import java.awt.Graphics;
@@ -16,6 +17,7 @@ import log.charter.CharterMain;
 import log.charter.data.ChartData;
 import log.charter.data.config.Config;
 import log.charter.data.config.Localization.Label;
+import log.charter.data.config.SystemType;
 import log.charter.data.song.Arrangement;
 import log.charter.gui.chartPanelDrawers.common.DrawerUtils;
 import log.charter.gui.components.containers.CharterScrollPane;
@@ -59,7 +61,7 @@ public class CharterFrame extends JFrame implements Initiable {
 	private ModeManager modeManager;
 	private TextTab textTab;
 
-	private final Preview3DPanel preview3DPanel = new Preview3DPanel();
+	private final Preview3DPanel preview3DPanel = SystemType.not(MAC) ? new Preview3DPanel() : null;
 
 	private CharterMenuBar charterMenuBar;
 	private ChartToolbar chartToolbar;
@@ -86,19 +88,30 @@ public class CharterFrame extends JFrame implements Initiable {
 
 	@Override
 	public void init() {
-		charterContext.initObject(preview3DPanel);
+		if (SystemType.not(MAC)) {
+			charterContext.initObject(preview3DPanel);
+		}
 
 		setSize(Config.windowWidth, Config.windowHeight);
 		setLocation(Config.windowPosX, Config.windowPosY);
 		setExtendedState(Config.windowExtendedState);
 
-		tabs = new CharterTabbedPane(//
-				new Tab(Label.TAB_QUICK_EDIT, new CharterScrollPane(currentSelectionEditor)), //
-				new Tab(Label.TAB_CHORD_TEMPLATES_EDITOR, new CharterScrollPane(chordTemplatesEditorTab)), //
-				new Tab(Label.TAB_ERRORS, errorsTab), //
-				new Tab(Label.TAB_3D_PREVIEW, preview3DPanel), //
-				new Tab(Label.TAB_TEXT, textTab), //
-				new Tab(Label.TAB_HELP, helpTab));
+		if (SystemType.is(MAC)) {
+			tabs = new CharterTabbedPane(//
+					new Tab(Label.TAB_QUICK_EDIT, new CharterScrollPane(currentSelectionEditor)), //
+					new Tab(Label.TAB_CHORD_TEMPLATES_EDITOR, new CharterScrollPane(chordTemplatesEditorTab)), //
+					new Tab(Label.TAB_ERRORS, errorsTab), //
+					new Tab(Label.TAB_TEXT, textTab), //
+					new Tab(Label.TAB_HELP, helpTab));
+		} else {
+			tabs = new CharterTabbedPane(//
+					new Tab(Label.TAB_QUICK_EDIT, new CharterScrollPane(currentSelectionEditor)), //
+					new Tab(Label.TAB_CHORD_TEMPLATES_EDITOR, new CharterScrollPane(chordTemplatesEditorTab)), //
+					new Tab(Label.TAB_ERRORS, errorsTab), //
+					new Tab(Label.TAB_3D_PREVIEW, preview3DPanel), //
+					new Tab(Label.TAB_TEXT, textTab), //
+					new Tab(Label.TAB_HELP, helpTab));
+		}
 
 		add(chartToolbar);
 		add(chartPanel);
@@ -161,6 +174,10 @@ public class CharterFrame extends JFrame implements Initiable {
 	}
 
 	public void reloadTextures() {
+		if (SystemType.is(MAC)) {
+			return;
+		}
+
 		preview3DPanel.reloadTextures();
 	}
 
@@ -173,7 +190,7 @@ public class CharterFrame extends JFrame implements Initiable {
 		paintWaiting = true;
 		super.repaint();
 
-		if (preview3DPanel.isShowing()) {
+		if (SystemType.not(MAC) && preview3DPanel.isShowing()) {
 			preview3DPanel.repaint();
 		}
 	}

--- a/src/main/java/log/charter/gui/chartPanelDrawers/instruments/guitar/highway/DefaultHighwayDrawer.java
+++ b/src/main/java/log/charter/gui/chartPanelDrawers/instruments/guitar/highway/DefaultHighwayDrawer.java
@@ -220,7 +220,8 @@ public class DefaultHighwayDrawer implements HighwayDrawer {
 
 	private void addSection(final Graphics2D g, final SectionType section, final int x) {
 		final TextWithBackground text = new TextWithBackground(new Position2D(x, sectionNamesY), anchorFont,
-				section.label, ColorLabel.SECTION_NAME_BG, ColorLabel.BASE_DARK_TEXT, ColorLabel.BASE_BORDER.color());
+				section.label.label(), ColorLabel.SECTION_NAME_BG, ColorLabel.BASE_DARK_TEXT,
+				ColorLabel.BASE_BORDER.color());
 
 		addEventPointTextIfOnScreen(text);
 	}

--- a/src/main/java/log/charter/gui/chartPanelDrawers/instruments/guitar/theme/modern/ModernThemeEvents.java
+++ b/src/main/java/log/charter/gui/chartPanelDrawers/instruments/guitar/theme/modern/ModernThemeEvents.java
@@ -42,7 +42,7 @@ public class ModernThemeEvents implements ThemeEvents {
 	}
 
 	private TextWithBackground generateSectionText(final SectionType section, final int x) {
-		return new TextWithBackground(new Position2D(x, sectionNamesY), eventFont, section.label,
+		return new TextWithBackground(new Position2D(x, sectionNamesY), eventFont, section.label.label(),
 				ColorLabel.ARRANGEMENT_TEXT, ColorLabel.SECTION_NAME_BG, 2, ColorLabel.BASE_BORDER);
 	}
 
@@ -76,7 +76,7 @@ public class ModernThemeEvents implements ThemeEvents {
 
 	@Override
 	public void addCurrentSection(final Graphics2D g, final SectionType section, final int nextSectionX) {
-		final ShapeSize expectedSize = TextWithBackground.getExpectedSize(g, eventFont, section.label,
+		final ShapeSize expectedSize = TextWithBackground.getExpectedSize(g, eventFont, section.label.label(),
 				sectionTextSpace);
 		final int x = min(0, nextSectionX - expectedSize.width);
 

--- a/src/main/java/log/charter/gui/components/simple/CharterSelect.java
+++ b/src/main/java/log/charter/gui/components/simple/CharterSelect.java
@@ -1,5 +1,7 @@
 package log.charter.gui.components.simple;
 
+import static java.util.Arrays.asList;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Vector;
@@ -13,6 +15,7 @@ import javax.swing.JComboBox;
 import log.charter.gui.ChartPanelColors.ColorLabel;
 
 public class CharterSelect<T> extends JComboBox<CharterSelect.ItemHolder<T>> {
+
 	public static class ItemHolder<T> {
 		public final T item;
 		private final String label;
@@ -36,6 +39,10 @@ public class CharterSelect<T> extends JComboBox<CharterSelect.ItemHolder<T>> {
 	private static <T> Vector<ItemHolder<T>> pack(final List<T> collection, final Function<T, String> labelGenerator) {
 		return collection.stream().map(e -> new ItemHolder<>(e, labelGenerator.apply(e)))
 				.collect(Collectors.toCollection(Vector::new));
+	}
+
+	private static <T> Function<T, String> defaultLabelGenerator() {
+		return v -> v == null ? "" : v.toString();
 	}
 
 	private static final long serialVersionUID = 1L;
@@ -62,7 +69,7 @@ public class CharterSelect<T> extends JComboBox<CharterSelect.ItemHolder<T>> {
 
 	public CharterSelect(final List<T> items, final T item, final Function<T, String> labelGenerator,
 			final Consumer<T> onPick) {
-		super(pack(items, labelGenerator));
+		super(pack(items, labelGenerator == null ? defaultLabelGenerator() : labelGenerator));
 
 		setSelectedIndex(findSelectedIndex(items, item));
 
@@ -73,29 +80,13 @@ public class CharterSelect<T> extends JComboBox<CharterSelect.ItemHolder<T>> {
 		setBackground(ColorLabel.BASE_BUTTON.color());
 	}
 
-	public CharterSelect(final List<T> items, final T item, final Function<T, String> labelGenerator) {
-		this(items, item, labelGenerator, null);
-	}
-
-	public CharterSelect(final List<T> items, final T item) {
-		this(items, item, T::toString);
-	}
-
 	public CharterSelect(final Stream<T> items, final T item, final Function<T, String> labelGenerator,
 			final Consumer<T> onPick) {
 		this(items.toList(), item, labelGenerator, onPick);
 	}
 
-	public CharterSelect(final Stream<T> items, final T item, final Function<T, String> labelGenerator) {
-		this(items, item, labelGenerator, null);
+	public CharterSelect(final T[] items, final T item, final Function<T, String> labelGenerator,
+			final Consumer<T> onPick) {
+		this(asList(items), item, labelGenerator, onPick);
 	}
-
-	public CharterSelect(final Stream<T> items, final T item, final Consumer<T> onPick) {
-		this(items, item, T::toString, onPick);
-	}
-
-	public CharterSelect(final Stream<T> items, final T item) {
-		this(items, item, T::toString);
-	}
-
 }

--- a/src/main/java/log/charter/gui/components/simple/CharterSelect.java
+++ b/src/main/java/log/charter/gui/components/simple/CharterSelect.java
@@ -10,6 +10,8 @@ import java.util.stream.Stream;
 
 import javax.swing.JComboBox;
 
+import log.charter.gui.ChartPanelColors.ColorLabel;
+
 public class CharterSelect<T> extends JComboBox<CharterSelect.ItemHolder<T>> {
 	public static class ItemHolder<T> {
 		public final T item;
@@ -67,6 +69,8 @@ public class CharterSelect<T> extends JComboBox<CharterSelect.ItemHolder<T>> {
 		if (onPick != null) {
 			addActionListener(e -> onPick.accept(getSelectedValue()));
 		}
+
+		setBackground(ColorLabel.BASE_BUTTON.color());
 	}
 
 	public CharterSelect(final List<T> items, final T item, final Function<T, String> labelGenerator) {

--- a/src/main/java/log/charter/gui/components/simple/LoadingDialog.java
+++ b/src/main/java/log/charter/gui/components/simple/LoadingDialog.java
@@ -1,4 +1,4 @@
-package log.charter.services.data.files;
+package log.charter.gui.components.simple;
 
 import java.util.function.Consumer;
 
@@ -23,8 +23,8 @@ public class LoadingDialog extends JDialog {
 			protected Void doInBackground() throws Exception {
 				try {
 					operation.accept(dialog);
-				} catch (final Exception e) {
-					Logger.error("error when executing operation " + operationName, e);
+				} catch (final Throwable t) {
+					Logger.error("error when executing operation " + operationName, t);
 				}
 
 				dialog.dispose();

--- a/src/main/java/log/charter/gui/components/simple/ShortcutEditor.java
+++ b/src/main/java/log/charter/gui/components/simple/ShortcutEditor.java
@@ -130,6 +130,11 @@ public class ShortcutEditor extends JButton implements ActionListener, FocusList
 			resetText();
 			return;
 		}
+		if (code == KeyEvent.VK_META) {
+			shortcut.command = true;
+			resetText();
+			return;
+		}
 
 		shortcut.key = code;
 		removeKeyListener(this);
@@ -156,6 +161,11 @@ public class ShortcutEditor extends JButton implements ActionListener, FocusList
 		}
 		if (e.getKeyCode() == KeyEvent.VK_ALT) {
 			shortcut.alt = false;
+			resetText();
+			return;
+		}
+		if (e.getKeyCode() == KeyEvent.VK_META) {
+			shortcut.command = false;
 			resetText();
 			return;
 		}

--- a/src/main/java/log/charter/gui/components/tabs/selectionEditor/chords/ChordNameAdviceButton.java
+++ b/src/main/java/log/charter/gui/components/tabs/selectionEditor/chords/ChordNameAdviceButton.java
@@ -7,6 +7,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -112,7 +113,7 @@ public class ChordNameAdviceButton extends JButton implements ActionListener, Mo
 	public void actionPerformed(final ActionEvent e) {
 		removePopup();
 
-		final ArrayList2<String> suggestedChordNames = suggestChordNames(tuningSupplier.get(), fretsSupplier.get());
+		final List<String> suggestedChordNames = suggestChordNames(tuningSupplier.get(), fretsSupplier.get());
 
 		final int x = getX();
 		int y = getY() + getHeight();

--- a/src/main/java/log/charter/gui/menuHandlers/FileMenuHandler.java
+++ b/src/main/java/log/charter/gui/menuHandlers/FileMenuHandler.java
@@ -61,6 +61,7 @@ public class FileMenuHandler extends CharterMenuHandler implements Initiable {
 		menu.add(createItem(Action.NEW_PROJECT));
 		menu.add(createItem(Action.OPEN_PROJECT));
 		menu.add(createItem(Label.CREATE_PROJECT_FROM_RS_XML, songFileHandler::createSongWithImportFromArrangementXML));
+//TODO create projects based on gp5/gp8/GPA files
 
 		if (modeManager.getMode() != EditMode.EMPTY) {
 			menu.add(createItem(Label.CHANGE_AUDIO, this::openAudioFile));

--- a/src/main/java/log/charter/gui/panes/colorConfig/ColorConfigPane.java
+++ b/src/main/java/log/charter/gui/panes/colorConfig/ColorConfigPane.java
@@ -59,7 +59,8 @@ public class ColorConfigPane extends ParamsPane {
 				.listFiles(FileUtils.colorSetsFolder, file -> file.getName().endsWith(".txt"))//
 				.map(name -> name.substring(0, name.length() - 4));
 
-		final CharterSelect<String> select = new CharterSelect<>(names, GraphicalConfig.colorSet, this::changeSet);
+		final CharterSelect<String> select = new CharterSelect<>(names, GraphicalConfig.colorSet, null,
+				this::changeSet);
 
 		add(select, 20, 0, 200, 20);
 

--- a/src/main/java/log/charter/gui/panes/graphicalConfig/GraphicTexturesConfigPage.java
+++ b/src/main/java/log/charter/gui/panes/graphicalConfig/GraphicTexturesConfigPage.java
@@ -21,6 +21,9 @@ public class GraphicTexturesConfigPage implements Page {
 	private FieldWithLabel<CharterSelect<String>> inlayField;
 	private FieldWithLabel<CharterSelect<String>> texturePackField;
 
+	private String inlay = GraphicalConfig.inlay;
+	private String texturePack = GraphicalConfig.texturePack;
+
 	@Override
 	public Label label() {
 		return Label.PAGE_TEXTURES;
@@ -38,7 +41,7 @@ public class GraphicTexturesConfigPage implements Page {
 		final Stream<String> names = listFiles(FileUtils.inlaysFolder, f -> f.getName().endsWith(".png"))//
 				.map(name -> name.substring(0, name.length() - 4));
 
-		final CharterSelect<String> inlaySelect = new CharterSelect<>(names, GraphicalConfig.inlay);
+		final CharterSelect<String> inlaySelect = new CharterSelect<>(names, inlay, null, v -> inlay = v);
 		inlayField = new FieldWithLabel<>(Label.GRAPHIC_CONFIG_INLAY, 90, 150, 20, inlaySelect, LabelPosition.LEFT);
 		panel.add(inlayField, position);
 	}
@@ -46,7 +49,8 @@ public class GraphicTexturesConfigPage implements Page {
 	private void addTexturePackSelect(final RowedPanel panel, final RowedPosition position) {
 		final List<String> names = listDirectories(FileUtils.texturesFolder);
 
-		final CharterSelect<String> texturePackSelect = new CharterSelect<>(names, GraphicalConfig.texturePack);
+		final CharterSelect<String> texturePackSelect = new CharterSelect<>(names, texturePack, null,
+				v -> texturePack = v);
 		texturePackField = new FieldWithLabel<>(Label.GRAPHIC_CONFIG_TEXTURE_PACK, 90, 150, 20, texturePackSelect,
 				LabelPosition.LEFT);
 		panel.add(texturePackField, position);
@@ -60,12 +64,12 @@ public class GraphicTexturesConfigPage implements Page {
 
 	public void save(final CharterContext context) {
 		boolean texturesChanged = false;
-		if (!inlayField.field.getSelectedItem().equals(GraphicalConfig.inlay)) {
-			GraphicalConfig.inlay = inlayField.field.getSelectedValue();
+		if (!inlay.equals(GraphicalConfig.inlay)) {
+			GraphicalConfig.inlay = inlay;
 			texturesChanged = true;
 		}
-		if (!texturePackField.field.getSelectedItem().equals(GraphicalConfig.texturePack)) {
-			GraphicalConfig.texturePack = texturePackField.field.getSelectedValue();
+		if (!texturePack.equals(GraphicalConfig.texturePack)) {
+			GraphicalConfig.texturePack = texturePack;
 			texturesChanged = true;
 		}
 

--- a/src/main/java/log/charter/gui/panes/graphicalConfig/GraphicThemeConfigPage.java
+++ b/src/main/java/log/charter/gui/panes/graphicalConfig/GraphicThemeConfigPage.java
@@ -1,14 +1,11 @@
 package log.charter.gui.panes.graphicalConfig;
 
-import static java.util.Arrays.asList;
 import static log.charter.gui.components.simple.TextInputWithValidation.generateForBigDecimal;
 import static log.charter.gui.components.simple.TextInputWithValidation.generateForInt;
 import static log.charter.gui.components.utils.TextInputSelectAllOnFocus.addSelectTextOnFocus;
 
 import java.math.BigDecimal;
-import java.util.Vector;
 
-import javax.swing.JComboBox;
 import javax.swing.JTextField;
 
 import log.charter.data.config.GraphicalConfig;
@@ -16,6 +13,7 @@ import log.charter.data.config.Localization.Label;
 import log.charter.data.config.Theme;
 import log.charter.gui.components.containers.Page;
 import log.charter.gui.components.containers.RowedPanel;
+import log.charter.gui.components.simple.CharterSelect;
 import log.charter.gui.components.simple.FieldWithLabel;
 import log.charter.gui.components.simple.FieldWithLabel.LabelPosition;
 import log.charter.gui.components.simple.TextInputWithValidation;
@@ -29,21 +27,6 @@ public class GraphicThemeConfigPage implements Page {
 	private static final BigDecimalValueValidator scrollSpeedValidator = new BigDecimalValueValidator(
 			new BigDecimal("0.1"), new BigDecimal("2.0"), false);
 
-	private static class ThemeHolder {
-		public final Theme theme;
-		public final Label label;
-
-		public ThemeHolder(final Theme theme, final Label label) {
-			this.theme = theme;
-			this.label = label;
-		}
-
-		@Override
-		public String toString() {
-			return label.label();
-		}
-	}
-
 	private Theme theme = GraphicalConfig.theme;
 
 	private int eventsChangeHeight = GraphicalConfig.eventsChangeHeight;
@@ -56,7 +39,7 @@ public class GraphicThemeConfigPage implements Page {
 	private int timingHeight = GraphicalConfig.timingHeight;
 	private BigDecimal previewScrollSpeed = BigDecimal.valueOf(GraphicalConfig.previewWindowScrollSpeed);
 
-	private FieldWithLabel<JComboBox<ThemeHolder>> themeField;
+	private FieldWithLabel<CharterSelect<Theme>> themeField;
 	private FieldWithLabel<TextInputWithValidation> noteHeightField;
 	private FieldWithLabel<TextInputWithValidation> noteWidthField;
 	private FieldWithLabel<TextInputWithValidation> chordHeightField;
@@ -96,25 +79,6 @@ public class GraphicThemeConfigPage implements Page {
 		addScrollSpeedFieldField(panel, position);
 	}
 
-	private void addThemePicker(final RowedPanel panel, final RowedPosition position) {
-		final Vector<ThemeHolder> themes = new Vector<>(asList(//
-				new ThemeHolder(Theme.MODERN, Label.THEME_MODERN), //
-				new ThemeHolder(Theme.SQUARE, Label.THEME_SQUARE), //
-				new ThemeHolder(Theme.BASIC, Label.THEME_BASIC)));
-
-		final JComboBox<ThemeHolder> themeSelect = new JComboBox<>(themes);
-		for (int i = 0; i < themes.size(); i++) {
-			if (themes.get(i).theme == theme) {
-				themeSelect.setSelectedIndex(i);
-				break;
-			}
-		}
-		themeSelect.addActionListener(e -> onThemeChange(((ThemeHolder) themeSelect.getSelectedItem()).theme));
-
-		themeField = new FieldWithLabel<>(Label.GRAPHIC_CONFIG_THEME, 60, 150, 20, themeSelect, LabelPosition.LEFT);
-		panel.add(themeField, position);
-	}
-
 	private void onThemeChange(final Theme newTheme) {
 		theme = newTheme;
 
@@ -124,6 +88,14 @@ public class GraphicThemeConfigPage implements Page {
 		} else {
 			noteWidthField.setVisible(true);
 		}
+	}
+
+	private void addThemePicker(final RowedPanel panel, final RowedPosition position) {
+		final CharterSelect<Theme> input = new CharterSelect<>(Theme.values(), theme, v -> v.label.label(),
+				this::onThemeChange);
+
+		themeField = new FieldWithLabel<>(Label.GRAPHIC_CONFIG_THEME, 60, 150, 20, input, LabelPosition.LEFT);
+		panel.add(themeField, position);
 	}
 
 	private void addEventsChangeHeightField(final RowedPanel panel, final RowedPosition position) {

--- a/src/main/java/log/charter/gui/panes/imports/ArrangementImportOptions.java
+++ b/src/main/java/log/charter/gui/panes/imports/ArrangementImportOptions.java
@@ -1,10 +1,7 @@
 package log.charter.gui.panes.imports;
 
-import static java.util.Arrays.asList;
-
-import java.util.Vector;
-
-import javax.swing.JComboBox;
+import java.util.ArrayList;
+import java.util.List;
 
 import log.charter.data.ChartData;
 import log.charter.data.config.Localization.Label;
@@ -12,10 +9,11 @@ import log.charter.data.song.Arrangement;
 import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.components.containers.ParamsPane;
+import log.charter.gui.components.simple.CharterSelect;
 import log.charter.gui.menuHandlers.CharterMenuBar;
 import log.charter.services.data.fixers.ArrangementFixer;
 
-public class GPImportOptions extends ParamsPane {
+public class ArrangementImportOptions extends ParamsPane {
 	private static class ArrangementImportSetting {
 		public final boolean skip;
 		public final Integer arrangementId;
@@ -47,10 +45,11 @@ public class GPImportOptions extends ParamsPane {
 	private final SongChart imported;
 
 	private final ArrangementImportSetting[] arrangementImportSettings;
+	private final List<ArrangementImportSetting> arrangementImportSettingsOptions;
 
-	public GPImportOptions(final CharterFrame frame, final ArrangementFixer arrangementFixer,
+	public ArrangementImportOptions(final CharterFrame frame, final ArrangementFixer arrangementFixer,
 			final CharterMenuBar charterMenuBar, final ChartData data, final SongChart imported) {
-		super(frame, Label.GP_IMPORT_OPTIONS, 450);
+		super(frame, Label.ARRANGEMENT_IMPORT_OPTIONS, 450);
 
 		this.arrangementFixer = arrangementFixer;
 		this.charterMenuBar = charterMenuBar;
@@ -61,6 +60,8 @@ public class GPImportOptions extends ParamsPane {
 
 		int arrangementId = 0;
 		arrangementImportSettings = new ArrangementImportSetting[imported.arrangements.size()];
+		arrangementImportSettingsOptions = prepareArrangementImportSettingsOptions();
+
 		for (final Arrangement arrangement : imported.arrangements) {
 			addArrangementOptions(row++, arrangementId++, arrangement);
 		}
@@ -69,24 +70,28 @@ public class GPImportOptions extends ParamsPane {
 		addDefaultFinish(row, this::saveAndExit);
 	}
 
-	private void addArrangementOptions(final int row, final int id, final Arrangement arrangement) {
-		final String name = Label.GP_IMPORT_ARRANGEMENT_NAME.label().formatted(id + 1, arrangement.getTypeNameLabel());
-
-		addLabel(row, 10, name, 0);
-		final Vector<ArrangementImportSetting> options = new Vector<>(asList(//
-				new ArrangementImportSetting(false, Label.GP_IMPORT_TO_NEW_ARRANGEMENT.label()), //
-				new ArrangementImportSetting(true, Label.GP_IMPORT_SKIP_ARRANGEMENT.label())));
+	private List<ArrangementImportSetting> prepareArrangementImportSettingsOptions() {
+		final List<ArrangementImportSetting> options = new ArrayList<>();
+		options.add(new ArrangementImportSetting(false, Label.ARRANGEMENT_TO_NEW_ARRANGEMENT.label()));
+		options.add(new ArrangementImportSetting(true, Label.ARRANGEMENT_SKIP_ARRANGEMENT.label()));
 		for (int i = 0; i < data.songChart.arrangements.size(); i++) {
-			final String optionName = Label.GP_IMPORT_TO_EXISTING_ARRANGEMENT.label().formatted(i + 1,
-					data.songChart.arrangements.get(i).getTypeNameLabel());
+			final String arrangementTypeAndName = data.songChart.arrangements.get(i).getTypeNameLabel();
+			final String optionName = Label.ARRANGEMENT_TO_EXISTING_ARRANGEMENT.format(i + 1, arrangementTypeAndName);
 			options.add(new ArrangementImportSetting(i, optionName));
 		}
-		arrangementImportSettings[id] = options.get(0);
 
-		final JComboBox<ArrangementImportSetting> themeSelect = new JComboBox<>(options);
-		themeSelect.setSelectedIndex(0);
-		themeSelect.addActionListener(
-				e -> arrangementImportSettings[id] = ((ArrangementImportSetting) themeSelect.getSelectedItem()));
+		return options;
+	}
+
+	private void addArrangementOptions(final int row, final int id, final Arrangement arrangement) {
+		final String name = Label.ARRANGEMENT_ID_NAME.label().formatted(id + 1, arrangement.getTypeNameLabel());
+
+		addLabel(row, 10, name, 0);
+		arrangementImportSettings[id] = arrangementImportSettingsOptions.get(0);
+
+		final CharterSelect<ArrangementImportSetting> themeSelect = new CharterSelect<>(
+				arrangementImportSettingsOptions, null, v -> v.name, v -> arrangementImportSettings[id] = v);
+
 		this.add(themeSelect, 200, getY(row), 200, 20);
 	}
 

--- a/src/main/java/log/charter/gui/panes/programConfig/ProgramAudioConfigPage.java
+++ b/src/main/java/log/charter/gui/panes/programConfig/ProgramAudioConfigPage.java
@@ -1,5 +1,6 @@
 package log.charter.gui.panes.programConfig;
 
+import static log.charter.data.config.SystemType.WINDOWS;
 import static log.charter.gui.components.simple.TextInputWithValidation.generateForInt;
 
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ import com.synthbot.jasiohost.AsioDriver;
 
 import log.charter.data.config.Config;
 import log.charter.data.config.Localization.Label;
+import log.charter.data.config.SystemType;
 import log.charter.gui.components.containers.Page;
 import log.charter.gui.components.containers.RowedPanel;
 import log.charter.gui.components.simple.CharterSelect;
@@ -85,12 +87,14 @@ public class ProgramAudioConfigPage implements Page {
 
 	@Override
 	public void init(final RowedPanel panel, final RowedPosition position) {
-		addAudioOutputSystemSelect(panel, position);
-		position.newRow();
+		if (SystemType.is(WINDOWS)) {
+			addAudioOutputSystemSelect(panel, position);
+			position.newRow();
 
-		addLeftOutChannelId(panel, position);
-		addRightOutChannelId(panel, position);
-		position.newRow();
+			addLeftOutChannelId(panel, position);
+			addRightOutChannelId(panel, position);
+			position.newRow();
+		}
 
 		addAudioBufferMs(panel, position);
 		position.newRow();
@@ -101,8 +105,6 @@ public class ProgramAudioConfigPage implements Page {
 		addDelay(panel, position);
 		addMidiDelay(panel, position);
 		position.newRow();
-
-		showChannelIdsFields(audioOutSystemType == AudioSystemType.ASIO);
 	}
 
 	private List<AudioOutputData> getASIOOutputsList() {
@@ -202,8 +204,10 @@ public class ProgramAudioConfigPage implements Page {
 
 	@Override
 	public void setVisible(final boolean visibility) {
-		audioOutSystemField.setVisible(visibility);
-		showChannelIdsFields(visibility && audioOutSystemType == AudioSystemType.ASIO);
+		if (SystemType.is(WINDOWS)) {
+			audioOutSystemField.setVisible(visibility);
+			showChannelIdsFields(visibility && audioOutSystemType == AudioSystemType.ASIO);
+		}
 		audioBufferMsField.setVisible(visibility);
 		baseAudioFormatField.setVisible(visibility);
 		delayField.setVisible(visibility);

--- a/src/main/java/log/charter/gui/panes/programConfig/ProgramDisplayConfigPage.java
+++ b/src/main/java/log/charter/gui/panes/programConfig/ProgramDisplayConfigPage.java
@@ -1,11 +1,13 @@
 package log.charter.gui.panes.programConfig;
 
+import static log.charter.data.config.SystemType.MAC;
 import static log.charter.gui.components.simple.TextInputWithValidation.generateForInt;
 
 import javax.swing.JCheckBox;
 
 import log.charter.data.config.Config;
 import log.charter.data.config.Localization.Label;
+import log.charter.data.config.SystemType;
 import log.charter.gui.components.containers.Page;
 import log.charter.gui.components.containers.RowedPanel;
 import log.charter.gui.components.simple.FieldWithLabel;
@@ -40,11 +42,13 @@ public class ProgramDisplayConfigPage implements Page {
 		position.newRow();
 
 		addInvertStrings(panel, position);
-		position.addX(20);
-		addInvertStrings3D(panel, position);
-		position.newRow();
+		if (SystemType.not(MAC)) {
+			position.addX(20);
+			addInvertStrings3D(panel, position);
+			position.newRow();
 
-		addLeftHanded(panel, position);
+			addLeftHanded(panel, position);
+		}
 		position.newRow();
 
 		addshowTempoInsteadOfBPM(panel, position);
@@ -141,8 +145,10 @@ public class ProgramDisplayConfigPage implements Page {
 	public void setVisible(final boolean visibility) {
 		markerOffsetField.setVisible(visibility);
 		invertStringsField.setVisible(visibility);
-		invertStrings3DField.setVisible(visibility);
-		leftHandedField.setVisible(visibility);
+		if (SystemType.not(MAC)) {
+			invertStrings3DField.setVisible(visibility);
+			leftHandedField.setVisible(visibility);
+		}
 		showTempoInsteadOfBPMField.setVisible(visibility);
 		showChordIdsField.setVisible(visibility);
 		showGridField.setVisible(visibility);

--- a/src/main/java/log/charter/gui/panes/songSettings/ArrangementSettingsPane.java
+++ b/src/main/java/log/charter/gui/panes/songSettings/ArrangementSettingsPane.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
 
@@ -28,6 +27,7 @@ import log.charter.data.song.configs.Tuning;
 import log.charter.data.song.configs.Tuning.TuningType;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.components.containers.ParamsPane;
+import log.charter.gui.components.simple.CharterSelect;
 import log.charter.gui.components.simple.FieldWithLabel;
 import log.charter.gui.components.simple.FieldWithLabel.LabelPosition;
 import log.charter.gui.components.simple.TextInputWithValidation;
@@ -36,23 +36,9 @@ import log.charter.gui.menuHandlers.CharterMenuBar;
 import log.charter.io.rs.xml.song.ArrangementType;
 import log.charter.services.data.selection.SelectionManager;
 import log.charter.sound.data.AudioUtils;
-import log.charter.util.collections.ArrayList2;
 
 public class ArrangementSettingsPane extends ParamsPane {
 	private static final long serialVersionUID = -3193534671039163160L;
-
-	private class TuningTypeHolder {
-		public final TuningType tuningType;
-
-		private TuningTypeHolder(final TuningType tuningType) {
-			this.tuningType = tuningType;
-		}
-
-		@Override
-		public String toString() {
-			return tuningType.nameWithValues(tuning.strings());
-		}
-	}
 
 	private final CharterMenuBar charterMenuBar;
 	private final ChartData data;
@@ -60,7 +46,7 @@ public class ArrangementSettingsPane extends ParamsPane {
 	private final SelectionManager selectionManager;
 
 	private final JLabel centOffsetLabel;
-	private JComboBox<TuningTypeHolder> tuningSelect;
+	private CharterSelect<TuningType> tuningSelect;
 	private final int tuningInputsRow;
 	private final List<TextInputWithValidation> tuningInputs = new ArrayList<>();
 	private final List<JLabel> tuningLabels = new ArrayList<>();
@@ -164,33 +150,34 @@ public class ArrangementSettingsPane extends ParamsPane {
 		setCentsValue();
 	}
 
+	private void setArrangementType(final ArrangementType newArrangementType) {
+		arrangementType = newArrangementType;
+		setTuningLabels();
+	}
+
 	private void addArrangmentType(final AtomicInteger row) {
-		final JComboBox<ArrangementType> arrangementTypeInput = new JComboBox<>(ArrangementType.values());
-		arrangementTypeInput.setSelectedItem(arrangementType);
-		arrangementTypeInput.addActionListener(e -> {
-			arrangementType = (ArrangementType) arrangementTypeInput.getSelectedItem();
-			setTuningLabels();
-		});
+		final CharterSelect<ArrangementType> input = new CharterSelect<>(ArrangementType.values(), arrangementType,
+				v -> v.name(), this::setArrangementType);
+
 		addLabel(row.get(), 20, Label.ARRANGEMENT_OPTIONS_TYPE, 0);
-		add(arrangementTypeInput, 150, getY(row.getAndIncrement()), 100, 20);
+		add(input, 150, getY(row.getAndIncrement()), 100, 20);
+	}
+
+	private void setArrangementSubtype(final ArrangementSubtype newArrangementSubtype) {
+		arrangementSubtype = newArrangementSubtype;
 	}
 
 	private void addArrangmentSubtype(final AtomicInteger row) {
-		final JComboBox<ArrangementSubtype> arrangementSubtypeInput = new JComboBox<>(ArrangementSubtype.values());
-		arrangementSubtypeInput.setSelectedItem(arrangementSubtype);
-		arrangementSubtypeInput.addActionListener(e -> {
-			arrangementSubtype = (ArrangementSubtype) arrangementSubtypeInput.getSelectedItem();
-		});
+		final CharterSelect<ArrangementSubtype> input = new CharterSelect<>(ArrangementSubtype.values(),
+				arrangementSubtype, v -> v.label.label(), this::setArrangementSubtype);
+
 		addLabel(row.get(), 20, Label.ARRANGEMENT_OPTIONS_SUBTYPE, 0);
-		add(arrangementSubtypeInput, 150, getY(row.getAndIncrement()), 100, 20);
+		add(input, 150, getY(row.getAndIncrement()), 100, 20);
 	}
 
 	private void addTuningSelect(final AtomicInteger row) {
-		final List<TuningTypeHolder> values = new ArrayList2<>(TuningType.values()).map(TuningTypeHolder::new);
-		tuningSelect = new JComboBox<>(values.toArray(new TuningTypeHolder[0]));
-		tuningSelect.setSelectedIndex(tuning.tuningType.ordinal());
-		tuningSelect.addActionListener(
-				e -> onTuningSelected(((TuningTypeHolder) tuningSelect.getSelectedItem()).tuningType));
+		tuningSelect = new CharterSelect<>(TuningType.values(), tuning.tuningType, v -> v.name, this::onTuningSelected);
+
 		addLabel(row.get(), 20, Label.ARRANGEMENT_OPTIONS_TUNING_TYPE, 0);
 		this.add(tuningSelect, 75, getY(row.getAndIncrement()), 200, 20);
 	}

--- a/src/main/java/log/charter/io/gp/gp7/GP7PlusFileImporter.java
+++ b/src/main/java/log/charter/io/gp/gp7/GP7PlusFileImporter.java
@@ -16,7 +16,7 @@ import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.components.utils.ComponentUtils.ConfirmAnswer;
 import log.charter.gui.menuHandlers.CharterMenuBar;
-import log.charter.gui.panes.imports.GPImportOptions;
+import log.charter.gui.panes.imports.ArrangementImportOptions;
 import log.charter.io.Logger;
 import log.charter.io.gp.gp7.data.GP7Automation;
 import log.charter.io.gp.gp7.data.GP7MasterBar;
@@ -160,6 +160,6 @@ public class GP7PlusFileImporter {
 		final BeatsMap beatsMap = replaceTempoMap(gpif);
 		final SongChart temporaryChart = GP7FileToSongChart.transform(gpif, beatsMap);
 
-		new GPImportOptions(charterFrame, arrangementFixer, charterMenuBar, chartData, temporaryChart);
+		new ArrangementImportOptions(charterFrame, arrangementFixer, charterMenuBar, chartData, temporaryChart);
 	}
 }

--- a/src/main/java/log/charter/io/gpa/GpaSyncPoint.java
+++ b/src/main/java/log/charter/io/gpa/GpaSyncPoint.java
@@ -1,0 +1,15 @@
+package log.charter.io.gpa;
+
+public class GpaSyncPoint {
+	public final double trackTime;
+	public final int bar;
+	public final double positionInBar;
+	public final double beatLength;
+
+	public GpaSyncPoint(final double trackTime, final int bar, final double positionInBar, final double beatLength) {
+		this.trackTime = trackTime;
+		this.bar = bar;
+		this.positionInBar = positionInBar;
+		this.beatLength = beatLength;
+	}
+}

--- a/src/main/java/log/charter/io/gpa/GpaSyncPointsConverter.java
+++ b/src/main/java/log/charter/io/gpa/GpaSyncPointsConverter.java
@@ -1,0 +1,41 @@
+package log.charter.io.gpa;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.thoughtworks.xstream.converters.SingleValueConverter;
+
+public class GpaSyncPointsConverter implements SingleValueConverter {
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public boolean canConvert(final Class type) {
+		return true;
+	}
+
+	@Override
+	public String toString(final Object obj) {
+		return "";
+	}
+
+	@Override
+	public List<GpaSyncPoint> fromString(final String str) {
+		final List<GpaSyncPoint> syncPoints = new ArrayList<>();
+
+		for (final String syncPointData : str.split("#")) {
+			final String[] tokens = syncPointData.split(";");
+			if (tokens.length < 4) {
+				continue;
+			}
+
+			final double trackTime = Double.valueOf(tokens[0]);
+			final int bar = Integer.valueOf(tokens[1]);
+			final double positionInBar = Double.valueOf(tokens[2]);
+			final double beatLength = Double.valueOf(tokens[3]);
+			syncPoints.add(new GpaSyncPoint(trackTime, bar, positionInBar, beatLength));
+		}
+
+		return syncPoints;
+	}
+
+}

--- a/src/main/java/log/charter/io/gpa/GpaTrack.java
+++ b/src/main/java/log/charter/io/gpa/GpaTrack.java
@@ -1,0 +1,23 @@
+package log.charter.io.gpa;
+
+import java.util.List;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+
+@XStreamAlias("track")
+public class GpaTrack {
+	@XStreamAsAttribute
+	public int id;
+	@XStreamAsAttribute
+	public String title;
+	@XStreamAsAttribute
+	public String artist;
+
+	public String scoreUrl;
+	public String audioUrl;
+	@XStreamAlias("sync")
+	@XStreamConverter(GpaSyncPointsConverter.class)
+	public List<GpaSyncPoint> syncPoints;
+}

--- a/src/main/java/log/charter/io/gpa/GpaXmlXStreamHandler.java
+++ b/src/main/java/log/charter/io/gpa/GpaXmlXStreamHandler.java
@@ -1,0 +1,33 @@
+package log.charter.io.gpa;
+
+import java.io.File;
+
+import com.thoughtworks.xstream.XStream;
+
+import log.charter.util.RW;
+
+public class GpaXmlXStreamHandler {
+	private static XStream xstream = prepareXStream();
+
+	private static XStream prepareXStream() {
+		final XStream xstream = new XStream();
+		xstream.ignoreUnknownElements();
+		xstream.processAnnotations(GpaTrack.class);
+		xstream.allowTypes(new Class[] { //
+				GpaSyncPoint.class, //
+				GpaTrack.class });
+
+		return xstream;
+	}
+
+	public static GpaTrack readGpaTrack(final File file) {
+		final String content = RW.read(file);
+
+		final Object o = xstream.fromXML(content);
+		if (!o.getClass().isAssignableFrom(GpaTrack.class)) {
+			return null;
+		}
+
+		return (GpaTrack) o;
+	}
+}

--- a/src/main/java/log/charter/services/ActionHandler.java
+++ b/src/main/java/log/charter/services/ActionHandler.java
@@ -73,7 +73,11 @@ public class ActionHandler implements Initiable {
 				modeManager.setMode(EditMode.VOCALS);
 				break;
 			case VOCALS:
-				modeManager.setArrangement(0);
+				if (chartData.songChart.arrangements.isEmpty()) {
+					modeManager.setMode(EditMode.TEMPO_MAP);
+				} else {
+					modeManager.setArrangement(0);
+				}
 				break;
 			case GUITAR:
 				if (chartData.currentArrangement >= chartData.songChart.arrangements.size() - 1) {
@@ -92,7 +96,11 @@ public class ActionHandler implements Initiable {
 	private void previousArrangement() {
 		switch (modeManager.getMode()) {
 			case TEMPO_MAP:
-				modeManager.setArrangement(chartData.songChart.arrangements.size() - 1);
+				if (chartData.songChart.arrangements.isEmpty()) {
+					modeManager.setMode(EditMode.VOCALS);
+				} else {
+					modeManager.setArrangement(chartData.songChart.arrangements.size() - 1);
+				}
 				break;
 			case VOCALS:
 				modeManager.setMode(EditMode.TEMPO_MAP);

--- a/src/main/java/log/charter/services/CharterContext.java
+++ b/src/main/java/log/charter/services/CharterContext.java
@@ -1,5 +1,6 @@
 package log.charter.services;
 
+import static log.charter.data.config.SystemType.MAC;
 import static log.charter.gui.components.utils.ComponentUtils.askYesNo;
 
 import java.lang.reflect.Field;
@@ -8,6 +9,7 @@ import java.util.Map;
 
 import log.charter.data.ChartData;
 import log.charter.data.config.Localization.Label;
+import log.charter.data.config.SystemType;
 import log.charter.data.undoSystem.UndoSystem;
 import log.charter.gui.ChartPanel;
 import log.charter.gui.CharterFrame;
@@ -40,6 +42,7 @@ import log.charter.services.data.copy.CopyManager;
 import log.charter.services.data.files.ExistingProjectImporter;
 import log.charter.services.data.files.FileDropHandler;
 import log.charter.services.data.files.GP5FileImporter;
+import log.charter.services.data.files.GpaXmlImporter;
 import log.charter.services.data.files.LRCImporter;
 import log.charter.services.data.files.MidiImporter;
 import log.charter.services.data.files.NewProjectCreator;
@@ -81,6 +84,7 @@ public class CharterContext {
 	private final FileDropHandler fileDropHandler = new FileDropHandler();
 	private final GP5FileImporter gp5FileImporter = new GP5FileImporter();
 	private final GP7PlusFileImporter gp7PlusFileImporter = new GP7PlusFileImporter();
+	private final GpaXmlImporter gpaXmlImporter = new GpaXmlImporter();
 	private final GuitarSoundsHandler guitarSoundsHandler = new GuitarSoundsHandler();
 	private final GuitarSoundsStatusesHandler guitarSoundsStatusesHandler = new GuitarSoundsStatusesHandler();
 	private final HandShapesHandler handShapesHandler = new HandShapesHandler();
@@ -209,7 +213,7 @@ public class CharterContext {
 			chartTimeHandler.frame(frameTime);
 			timer.addTimestamp("chartTimeHandler.frame()");
 
-			if (windowedPreviewHandler.isPreviewVisible()) {
+			if (SystemType.not(MAC) && windowedPreviewHandler.isPreviewVisible()) {
 				windowedPreviewHandler.paintFrame();
 				timer.addTimestamp("windowedPreviewHandler.paintFrame()");
 			}

--- a/src/main/java/log/charter/services/WindowedPreviewHandler.java
+++ b/src/main/java/log/charter/services/WindowedPreviewHandler.java
@@ -1,5 +1,8 @@
 package log.charter.services;
 
+import static log.charter.data.config.SystemType.MAC;
+
+import log.charter.data.config.SystemType;
 import log.charter.gui.components.preview3D.Preview3DFrame;
 import log.charter.gui.components.preview3D.Preview3DPanel;
 import log.charter.io.Logger;
@@ -8,25 +11,41 @@ import log.charter.services.CharterContext.Initiable;
 public class WindowedPreviewHandler implements Initiable {
 	private CharterContext charterContext;
 
-	private final Preview3DFrame windowedPreviewFrame = new Preview3DFrame();
-	private final Preview3DPanel windowedPreview3DPanel = new Preview3DPanel();
+	private final Preview3DFrame windowedPreviewFrame = SystemType.is(MAC) ? null : new Preview3DFrame();
+	private final Preview3DPanel windowedPreview3DPanel = SystemType.is(MAC) ? null : new Preview3DPanel();
 
 	@Override
 	public void init() {
+		if (SystemType.is(MAC)) {
+			return;
+		}
+
 		charterContext.initObject(windowedPreview3DPanel);
 		charterContext.initObject(windowedPreviewFrame);
 		windowedPreviewFrame.initWith(windowedPreview3DPanel);
 	}
 
 	public void reloadTextures() {
+		if (SystemType.is(MAC)) {
+			return;
+		}
+
 		windowedPreview3DPanel.reloadTextures();
 	}
 
 	public void switchWindowedPreview() {
+		if (SystemType.is(MAC)) {
+			return;
+		}
+
 		windowedPreviewFrame.setVisible(!windowedPreviewFrame.isVisible());
 	}
 
 	public void switchBorderlessWindowedPreview() {
+		if (SystemType.is(MAC)) {
+			return;
+		}
+
 		if (windowedPreviewFrame.isUndecorated()) {
 			windowedPreviewFrame.setWindowed();
 		} else {
@@ -35,6 +54,10 @@ public class WindowedPreviewHandler implements Initiable {
 	}
 
 	public void paintFrame() {
+		if (SystemType.is(MAC)) {
+			return;
+		}
+
 		try {
 			if (windowedPreviewFrame.isShowing()) {
 				windowedPreviewFrame.repaint();
@@ -46,6 +69,10 @@ public class WindowedPreviewHandler implements Initiable {
 	}
 
 	public boolean temporaryDispose() {
+		if (SystemType.is(MAC)) {
+			return false;
+		}
+
 		if (!windowedPreviewFrame.isVisible() || !windowedPreviewFrame.isFocused()) {
 			return false;
 		}
@@ -55,10 +82,18 @@ public class WindowedPreviewHandler implements Initiable {
 	}
 
 	public void restore() {
+		if (SystemType.is(MAC)) {
+			return;
+		}
+
 		windowedPreviewFrame.setVisible(true);
 	}
 
 	public boolean isPreviewVisible() {
+		if (SystemType.is(MAC)) {
+			return false;
+		}
+
 		return windowedPreviewFrame.isShowing();
 	}
 }

--- a/src/main/java/log/charter/services/data/GuitarSoundsHandler.java
+++ b/src/main/java/log/charter/services/data/GuitarSoundsHandler.java
@@ -30,7 +30,6 @@ import log.charter.gui.components.tabs.selectionEditor.CurrentSelectionEditor;
 import log.charter.services.data.selection.Selection;
 import log.charter.services.data.selection.SelectionManager;
 import log.charter.util.chordRecognition.ChordNameSuggester;
-import log.charter.util.collections.ArrayList2;
 import log.charter.util.collections.Pair;
 import log.charter.util.data.IntRange;
 
@@ -222,8 +221,8 @@ public class GuitarSoundsHandler {
 			return;
 		}
 
-		final ArrayList2<String> suggestedNames = ChordNameSuggester
-				.suggestChordNames(chartData.currentArrangement().tuning, template.frets);
+		final List<String> suggestedNames = ChordNameSuggester.suggestChordNames(chartData.currentArrangement().tuning,
+				template.frets);
 
 		if (!suggestedNames.isEmpty()) {
 			template.chordName = suggestedNames.get(0);

--- a/src/main/java/log/charter/services/data/ProjectAudioHandler.java
+++ b/src/main/java/log/charter/services/data/ProjectAudioHandler.java
@@ -7,7 +7,7 @@ import log.charter.data.config.Config;
 import log.charter.data.config.Localization.Label;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.chartPanelDrawers.common.waveform.WaveFormDrawer;
-import log.charter.services.data.files.LoadingDialog;
+import log.charter.gui.components.simple.LoadingDialog;
 import log.charter.services.data.files.SongFilesBackuper;
 import log.charter.sound.SoundFileType;
 import log.charter.sound.data.AudioData;

--- a/src/main/java/log/charter/services/data/files/ExistingProjectImporter.java
+++ b/src/main/java/log/charter/services/data/files/ExistingProjectImporter.java
@@ -1,8 +1,8 @@
 package log.charter.services.data.files;
 
+import static log.charter.gui.components.simple.LoadingDialog.doWithLoadingDialog;
 import static log.charter.gui.components.utils.ComponentUtils.showPopup;
 import static log.charter.io.rsc.xml.ChartProjectXStreamHandler.readChartProject;
-import static log.charter.services.data.files.LoadingDialog.doWithLoadingDialog;
 import static log.charter.services.data.files.SongFilesBackuper.makeBackups;
 
 import java.io.File;
@@ -13,6 +13,7 @@ import log.charter.data.ChartData;
 import log.charter.data.config.Localization.Label;
 import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
+import log.charter.gui.components.simple.LoadingDialog;
 import log.charter.gui.components.tabs.TextTab;
 import log.charter.gui.components.tabs.chordEditor.ChordTemplatesEditorTab;
 import log.charter.io.Logger;

--- a/src/main/java/log/charter/services/data/files/GP5FileImporter.java
+++ b/src/main/java/log/charter/services/data/files/GP5FileImporter.java
@@ -14,7 +14,7 @@ import log.charter.data.song.BeatsMap;
 import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.menuHandlers.CharterMenuBar;
-import log.charter.gui.panes.imports.GPImportOptions;
+import log.charter.gui.panes.imports.ArrangementImportOptions;
 import log.charter.io.Logger;
 import log.charter.io.gp.gp5.GP5FileReader;
 import log.charter.io.gp.gp5.data.GP5File;
@@ -60,6 +60,6 @@ public class GP5FileImporter {
 
 		final SongChart temporaryChart = GP5FileToSongChart.transform(gp5File, beatsMap, barsOrder);
 
-		new GPImportOptions(charterFrame, arrangementFixer, charterMenuBar, chartData, temporaryChart);
+		new ArrangementImportOptions(charterFrame, arrangementFixer, charterMenuBar, chartData, temporaryChart);
 	}
 }

--- a/src/main/java/log/charter/services/data/files/GpaXmlImporter.java
+++ b/src/main/java/log/charter/services/data/files/GpaXmlImporter.java
@@ -1,0 +1,44 @@
+package log.charter.services.data.files;
+
+import static log.charter.gui.components.utils.ComponentUtils.showPopup;
+
+import java.io.File;
+
+import log.charter.data.ChartData;
+import log.charter.data.config.Localization.Label;
+import log.charter.gui.CharterFrame;
+import log.charter.io.Logger;
+import log.charter.io.gpa.GpaTrack;
+import log.charter.io.gpa.GpaXmlXStreamHandler;
+
+public class GpaXmlImporter {
+	private ChartData chartData;
+	private CharterFrame charterFrame;
+	private FileDropHandler fileDropHandler;
+	private GpaXmlXStreamHandler gpaXmlXStreamHandler;
+
+	private void setMetadata(final GpaTrack gpaTrack) {
+		if (chartData.songChart.artistName().isBlank()) {
+			chartData.songChart.artistName(gpaTrack.artist);
+		}
+		if (chartData.songChart.title().isBlank()) {
+			chartData.songChart.title(gpaTrack.title);
+		}
+	}
+
+	public void importGpaXml(final File file) {
+		try {
+			final GpaTrack gpaTrack = GpaXmlXStreamHandler.readGpaTrack(file);
+			System.out.println(gpaTrack.scoreUrl);
+			setMetadata(gpaTrack);
+
+			// TODO try to load audio from given url (ask user)
+			// TODO try to load file from given tab url (ask user)
+			// TODO set tempo map
+
+		} catch (final Exception e) {
+			Logger.error("Couldn't load arrangement", e);
+			showPopup(charterFrame, Label.COULDNT_LOAD_ARRANGEMENT, e.getMessage());
+		}
+	}
+}

--- a/src/main/java/log/charter/services/mouseAndKeyboard/MouseHandler.java
+++ b/src/main/java/log/charter/services/mouseAndKeyboard/MouseHandler.java
@@ -13,8 +13,6 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.util.List;
 
-import org.jcodec.common.logging.Logger;
-
 import log.charter.data.ChartData;
 import log.charter.data.config.Zoom;
 import log.charter.data.song.BeatsMap.ImmutableBeatsMap;
@@ -28,6 +26,7 @@ import log.charter.data.types.PositionType;
 import log.charter.data.undoSystem.UndoSystem;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.panes.songEdits.VocalPane;
+import log.charter.io.Logger;
 import log.charter.services.ActionHandler;
 import log.charter.services.data.ChartTimeHandler;
 import log.charter.services.data.fixers.ArrangementFixer;

--- a/src/main/java/log/charter/services/mouseAndKeyboard/Shortcut.java
+++ b/src/main/java/log/charter/services/mouseAndKeyboard/Shortcut.java
@@ -6,17 +6,31 @@ import java.util.Objects;
 public class Shortcut {
 	public static Shortcut fromName(final String name) {
 		final String[] nameParts = name.split(" ");
-		if (nameParts.length < 4) {
-			return new Shortcut();
+		if (nameParts.length == 4 && (nameParts[0].equals("T") || nameParts[0].equals("F"))) {
+			return new Shortcut(nameParts[0].equals("T"), nameParts[1].equals("T"), nameParts[2].equals("T"),
+					Integer.valueOf(nameParts[3]));
 		}
 
-		return new Shortcut(nameParts[0].equals("T"), nameParts[1].equals("T"), nameParts[2].equals("T"),
-				Integer.valueOf(nameParts[3]));
+		final Shortcut shortcut = new Shortcut();
+
+		for (int i = 0; i < nameParts.length - 1; i++) {
+			switch (nameParts[i]) {
+				case "Ctrl" -> shortcut.ctrl = true;
+				case "Shift" -> shortcut.shift = true;
+				case "Alt" -> shortcut.alt = true;
+				case "Cmd" -> shortcut.command = true;
+			}
+		}
+
+		shortcut.key = Integer.valueOf(nameParts[nameParts.length - 1]);
+
+		return shortcut;
 	}
 
 	public boolean ctrl = false;
 	public boolean shift = false;
 	public boolean alt = false;
+	public boolean command = false;
 	public int key = -1;// key code from KeyEvent
 
 	public Shortcut() {
@@ -26,6 +40,7 @@ public class Shortcut {
 		ctrl = other.ctrl;
 		shift = other.shift;
 		alt = other.alt;
+		command = other.command;
 		key = other.key;
 	}
 
@@ -75,6 +90,9 @@ public class Shortcut {
 		if (alt) {
 			nameBuilder.append("Alt").append(joiner);
 		}
+		if (command) {
+			nameBuilder.append("Cmd").append(joiner);
+		}
 		if (key != -1) {
 			nameBuilder.append(KeyEvent.getKeyText(key));
 		}
@@ -83,7 +101,23 @@ public class Shortcut {
 	}
 
 	public String saveName() {
-		return (ctrl ? "T" : "F") + " " + (shift ? "T" : "F") + " " + (alt ? "T" : "F") + " " + key;
+		final StringBuilder b = new StringBuilder();
+		if (ctrl) {
+			b.append("Ctrl ");
+		}
+		if (shift) {
+			b.append("Shift ");
+		}
+		if (alt) {
+			b.append("Alt ");
+		}
+		if (command) {
+			b.append("Cmd ");
+		}
+
+		b.append(key);
+
+		return b.toString();
 	}
 
 	@Override

--- a/src/main/java/log/charter/sound/SoundFileType.java
+++ b/src/main/java/log/charter/sound/SoundFileType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.function.Function;
 
 import log.charter.data.config.Localization.Label;
-import log.charter.services.data.files.LoadingDialog;
+import log.charter.gui.components.simple.LoadingDialog;
 import log.charter.sound.audioFormats.flac.FlacLoader;
 import log.charter.sound.audioFormats.flac.FlacWriter;
 import log.charter.sound.audioFormats.mp3.Mp3Loader;

--- a/src/main/java/log/charter/sound/system/SoundSystem.java
+++ b/src/main/java/log/charter/sound/system/SoundSystem.java
@@ -3,6 +3,7 @@ package log.charter.sound.system;
 import java.util.function.DoubleSupplier;
 
 import log.charter.data.config.Config;
+import log.charter.io.Logger;
 import log.charter.sound.asio.ASIOHandler;
 import log.charter.sound.data.AudioData;
 import log.charter.sound.effects.Effect;
@@ -15,12 +16,18 @@ public class SoundSystem {
 	private static ISoundSystem currentSoundSystem = new StandardSoundSystem();
 
 	public static void setCurrentSoundSystem() {
-		currentSoundSystem = switch (Config.audioOutSystemType) {
-			case ASIO -> new ASIOSoundSystem();
-			default -> new StandardSoundSystem();
-		};
+		try {
+			currentSoundSystem = switch (Config.audioOutSystemType) {
+				case ASIO -> new ASIOSoundSystem();
+				default -> new StandardSoundSystem();
+			};
 
-		ASIOHandler.refresh();
+			ASIOHandler.refresh();
+		} catch (final Throwable t) {
+			Logger.error("Couldn't initialize audio system, setting output to default", t);
+			Config.audioOutSystemType = AudioSystemType.DEFAULT;
+			setCurrentSoundSystem();
+		}
 	}
 
 	public static ISoundSystem getCurrentSoundSystem() {

--- a/src/main/java/log/charter/sound/system/data/Player.java
+++ b/src/main/java/log/charter/sound/system/data/Player.java
@@ -41,7 +41,7 @@ public class Player {
 		frameSize = musicData.playingFormat.getFrameSize();
 
 		this.effect = effect;
-		if (speed == 100) {
+		if (speed == 100 || !RubberBandStretcher.loaded) {
 			rubberBandStretcher = null;
 			stretchingSamplesQueue = null;
 		} else {
@@ -101,7 +101,7 @@ public class Player {
 	}
 
 	private float[][] stretch(final float[][] samples, final boolean lastBlock) {
-		if (speed == 100) {
+		if (rubberBandStretcher == null) {
 			return samples;
 		}
 

--- a/src/main/java/log/charter/util/chordRecognition/ChordNameAdder.java
+++ b/src/main/java/log/charter/util/chordRecognition/ChordNameAdder.java
@@ -1,6 +1,9 @@
 package log.charter.util.chordRecognition;
 
+import static java.util.Arrays.asList;
 import static log.charter.util.SoundUtils.soundToSimpleName;
+
+import java.util.List;
 
 import log.charter.util.collections.ArrayList2;
 
@@ -13,7 +16,7 @@ public class ChordNameAdder {
 	public static String sus = "sus";
 
 	static interface ChordTypeChecker {
-		boolean check(final int root, final ArrayList2<Integer> notes);
+		boolean check(final int root, final List<Integer> notes);
 	}
 
 	static interface ChordNameGenerator {
@@ -28,13 +31,13 @@ public class ChordNameAdder {
 		this.nameGenerator = nameGenerator;
 	}
 
-	void add(final int root, final ArrayList2<Integer> notes, final ArrayList2<String> foundNames) {
+	void add(final int root, final List<Integer> notes, final List<String> foundNames) {
 		if (checker.check(root, notes)) {
 			foundNames.add(nameGenerator.generate(root));
 		}
 	}
 
-	private static ChordTypeChecker makeSimpleChecker(final int... requiredTones) {
+	private static ChordTypeChecker notes(final int... requiredTones) {
 		return (root, notes) -> {
 			if (notes.size() != requiredTones.length + 1) {
 				return false;
@@ -62,66 +65,71 @@ public class ChordNameAdder {
 	// #13, 7 - 10 frets
 	// maj7 - 11 frets
 
-	private static String chordName(final int root, final String additions) {
-		return soundToSimpleName(root + 4, true) + additions;
+	private static ChordNameGenerator nameWith(final String additions) {
+		return new ChordNameGenerator() {
+
+			@Override
+			public String generate(final int root) {
+				return soundToSimpleName(root + 4, true) + additions;
+			}
+		};
 	}
 
-	private static ArrayList2<ChordNameAdder> adders = new ArrayList2<>(
-			new ChordNameAdder(makeSimpleChecker(1, 4, 7, 10), root -> chordName(root, "7(b9)")), //
-			new ChordNameAdder(makeSimpleChecker(1, 4, 8, 10), root -> chordName(root, "7(b9,b13)")), //
-			new ChordNameAdder(makeSimpleChecker(1, 4, 9, 10), root -> chordName(root, "13(b9)")), //
-			new ChordNameAdder(makeSimpleChecker(1, 5, 10), root -> chordName(root, "7" + sus + "(b9)")), //
+	private static List<ChordNameAdder> adders = asList(new ChordNameAdder(notes(1, 4, 7, 10), nameWith("7(b9)")), //
+			new ChordNameAdder(notes(1, 4, 8, 10), nameWith("7(b9,b13)")), //
+			new ChordNameAdder(notes(1, 4, 9, 10), nameWith("13(b9)")), //
+			new ChordNameAdder(notes(1, 5, 10), nameWith("7" + sus + "(b9)")), //
 
-			new ChordNameAdder(makeSimpleChecker(2, 3, 7), root -> chordName(root, min + add + "9")), //
-			new ChordNameAdder(makeSimpleChecker(2, 3, 7, 10), root -> chordName(root, min + "9")), //
-			new ChordNameAdder(makeSimpleChecker(2, 3, 9), root -> chordName(root, min + "6(9)")), //
-			new ChordNameAdder(makeSimpleChecker(2, 4, 7), root -> chordName(root, add + "9")), //
-			new ChordNameAdder(makeSimpleChecker(2, 4, 7, 10), root -> chordName(root, "9")), //
-			new ChordNameAdder(makeSimpleChecker(2, 4, 7, 11), root -> chordName(root, maj + "9")), //
-			new ChordNameAdder(makeSimpleChecker(2, 4, 9), root -> chordName(root, "6(9)")), //
-			new ChordNameAdder(makeSimpleChecker(2, 4, 9, 10), root -> chordName(root, "9(13)")), //
-			new ChordNameAdder(makeSimpleChecker(2, 4, 9, 11), root -> chordName(root, maj + "9(13)")), //
-			new ChordNameAdder(makeSimpleChecker(2, 5, 9, 10), root -> chordName(root, "13" + sus)), //
-			new ChordNameAdder(makeSimpleChecker(2, 5, 10), root -> chordName(root, "9" + sus)), //
-			new ChordNameAdder(makeSimpleChecker(2, 7), root -> chordName(root, sus + "2")), //
+			new ChordNameAdder(notes(2, 3, 7), nameWith(min + add + "9")), //
+			new ChordNameAdder(notes(2, 3, 7, 10), nameWith(min + "9")), //
+			new ChordNameAdder(notes(2, 3, 9), nameWith(min + "6(9)")), //
+			new ChordNameAdder(notes(2, 4, 7), nameWith(add + "9")), //
+			new ChordNameAdder(notes(2, 4, 7, 10), nameWith("9")), //
+			new ChordNameAdder(notes(2, 4, 7, 11), nameWith(maj + "9")), //
+			new ChordNameAdder(notes(2, 4, 9), nameWith("6(9)")), //
+			new ChordNameAdder(notes(2, 4, 9, 10), nameWith("9(13)")), //
+			new ChordNameAdder(notes(2, 4, 9, 11), nameWith(maj + "9(13)")), //
+			new ChordNameAdder(notes(2, 5, 9, 10), nameWith("13" + sus)), //
+			new ChordNameAdder(notes(2, 5, 10), nameWith("9" + sus)), //
+			new ChordNameAdder(notes(2, 7), nameWith(sus + "2")), //
 
-			new ChordNameAdder(makeSimpleChecker(3), root -> chordName(root, min)), //
-			new ChordNameAdder(makeSimpleChecker(3, 4, 10), root -> chordName(root, "7(#9)")), //
-			new ChordNameAdder(makeSimpleChecker(3, 5, 6, 10), root -> chordName(root, min + "11(b5)")), //
-			new ChordNameAdder(makeSimpleChecker(3, 5, 10), root -> chordName(root, min + "11")), //
-			new ChordNameAdder(makeSimpleChecker(3, 6, 8, 9), root -> chordName(root, dim + "b13")), //
-			new ChordNameAdder(makeSimpleChecker(3, 6, 9), root -> chordName(root, dim)), //
-			new ChordNameAdder(makeSimpleChecker(3, 6, 10), root -> chordName(root, min + "7(b5)")), //
-			new ChordNameAdder(makeSimpleChecker(3, 7), root -> chordName(root, min)), //
-			new ChordNameAdder(makeSimpleChecker(3, 7, 8, 10), root -> chordName(root, min + "7(b13)")), //
-			new ChordNameAdder(makeSimpleChecker(3, 7, 9), root -> chordName(root, min + "6")), //
-			new ChordNameAdder(makeSimpleChecker(3, 7, 9, 10), root -> chordName(root, min + "13")), //
-			new ChordNameAdder(makeSimpleChecker(3, 7, 11), root -> chordName(root, min + maj + "7")), //
-			new ChordNameAdder(makeSimpleChecker(3, 9, 10), root -> chordName(root, min + "13")), //
-			new ChordNameAdder(makeSimpleChecker(3, 10), root -> chordName(root, min + "7")), //
+			new ChordNameAdder(notes(3), nameWith(min)), //
+			new ChordNameAdder(notes(3, 4, 10), nameWith("7(#9)")), //
+			new ChordNameAdder(notes(3, 5, 6, 10), nameWith(min + "11(b5)")), //
+			new ChordNameAdder(notes(3, 5, 10), nameWith(min + "11")), //
+			new ChordNameAdder(notes(3, 6, 8, 9), nameWith(dim + "b13")), //
+			new ChordNameAdder(notes(3, 6, 9), nameWith(dim)), //
+			new ChordNameAdder(notes(3, 6, 10), nameWith(min + "7(b5)")), //
+			new ChordNameAdder(notes(3, 7), nameWith(min)), //
+			new ChordNameAdder(notes(3, 7, 8, 10), nameWith(min + "7(b13)")), //
+			new ChordNameAdder(notes(3, 7, 9), nameWith(min + "6")), //
+			new ChordNameAdder(notes(3, 7, 9, 10), nameWith(min + "13")), //
+			new ChordNameAdder(notes(3, 7, 11), nameWith(min + maj + "7")), //
+			new ChordNameAdder(notes(3, 9, 10), nameWith(min + "13")), //
+			new ChordNameAdder(notes(3, 10), nameWith(min + "7")), //
 
-			new ChordNameAdder(makeSimpleChecker(4), root -> chordName(root, "")), //
-			new ChordNameAdder(makeSimpleChecker(4, 6, 10), root -> chordName(root, "7(#11)")), //
-			new ChordNameAdder(makeSimpleChecker(4, 6, 10), root -> chordName(root, "7(b5)")), //
-			new ChordNameAdder(makeSimpleChecker(4, 6, 11), root -> chordName(root, maj + "7(#11)")), //
-			new ChordNameAdder(makeSimpleChecker(4, 7), root -> chordName(root, "")), //
-			new ChordNameAdder(makeSimpleChecker(4, 7, 11), root -> chordName(root, maj + "7")), //
-			new ChordNameAdder(makeSimpleChecker(4, 8), root -> chordName(root, aug)), //
-			new ChordNameAdder(makeSimpleChecker(4, 8, 10), root -> chordName(root, "7(#5)")), //
-			new ChordNameAdder(makeSimpleChecker(4, 8, 10), root -> chordName(root, "7(b13)")), //
-			new ChordNameAdder(makeSimpleChecker(4, 8, 11), root -> chordName(root, maj + "7(#5)")), //
-			new ChordNameAdder(makeSimpleChecker(4, 9), root -> chordName(root, "6")), //
-			new ChordNameAdder(makeSimpleChecker(4, 9, 10), root -> chordName(root, "13")), //
-			new ChordNameAdder(makeSimpleChecker(4, 9, 11), root -> chordName(root, maj + "13")), //
-			new ChordNameAdder(makeSimpleChecker(4, 10), root -> chordName(root, "7")), //
+			new ChordNameAdder(notes(4), nameWith("3")), //
+			new ChordNameAdder(notes(4, 6, 10), nameWith("7(#11)")), //
+			new ChordNameAdder(notes(4, 6, 10), nameWith("7(b5)")), //
+			new ChordNameAdder(notes(4, 6, 11), nameWith(maj + "7(#11)")), //
+			new ChordNameAdder(notes(4, 7), nameWith("")), //
+			new ChordNameAdder(notes(4, 7, 11), nameWith(maj + "7")), //
+			new ChordNameAdder(notes(4, 8), nameWith(aug)), //
+			new ChordNameAdder(notes(4, 8, 10), nameWith("7(#5)")), //
+			new ChordNameAdder(notes(4, 8, 10), nameWith("7(b13)")), //
+			new ChordNameAdder(notes(4, 8, 11), nameWith(maj + "7(#5)")), //
+			new ChordNameAdder(notes(4, 9), nameWith("6")), //
+			new ChordNameAdder(notes(4, 9, 10), nameWith("13")), //
+			new ChordNameAdder(notes(4, 9, 11), nameWith(maj + "13")), //
+			new ChordNameAdder(notes(4, 10), nameWith("7")), //
 
-			new ChordNameAdder(makeSimpleChecker(5, 7), root -> chordName(root, sus)), //
-			new ChordNameAdder(makeSimpleChecker(5, 7, 10), root -> chordName(root, "7" + sus)), //
+			new ChordNameAdder(notes(5, 7), nameWith(sus)), //
+			new ChordNameAdder(notes(5, 7, 10), nameWith("7" + sus)), //
 
-			new ChordNameAdder(makeSimpleChecker(7), root -> chordName(root, "5")));
+			new ChordNameAdder(notes(7), nameWith("5")));
 
-	public static ArrayList2<String> getSuggestedChordNames(final int root, final ArrayList2<Integer> notes) {
-		final ArrayList2<String> foundNames = new ArrayList2<>();
+	public static List<String> getSuggestedChordNames(final int root, final List<Integer> notes) {
+		final List<String> foundNames = new ArrayList2<>();
 		adders.forEach(adder -> adder.add(root, notes, foundNames));
 		return foundNames;
 	}

--- a/src/main/java/log/charter/util/chordRecognition/ChordNameSuggester.java
+++ b/src/main/java/log/charter/util/chordRecognition/ChordNameSuggester.java
@@ -1,17 +1,20 @@
 package log.charter.util.chordRecognition;
 
+import static java.util.Arrays.asList;
 import static log.charter.util.SoundUtils.soundToSimpleName;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import log.charter.data.song.configs.Tuning;
 import log.charter.util.collections.ArrayList2;
-import log.charter.util.collections.HashMap2;
 
 public class ChordNameSuggester {
-	private static ArrayList2<Integer> soundsToNotes(final int[] sounds) {
-		final ArrayList2<Integer> notes = new ArrayList2<>();
+	private static List<Integer> soundsToNotes(final int[] sounds) {
+		final List<Integer> notes = new ArrayList<>(sounds.length);
 		for (int i = 0; i < sounds.length; i++) {
 			int note = sounds[i];
 			while (note < 0) {
@@ -27,21 +30,23 @@ public class ChordNameSuggester {
 		return notes;
 	}
 
-	private static ArrayList2<String> recognizeChord(final int[] sounds) {
-		final ArrayList2<Integer> notes = soundsToNotes(sounds);
+	private static List<String> recognizeChord(final int[] sounds) {
+		final List<Integer> notes = soundsToNotes(sounds);
 		if (notes.size() == 1) {
-			return new ArrayList2<>(soundToSimpleName(notes.get(0), true));
+			return asList(soundToSimpleName(notes.get(0), true));
 		}
 
-		final ArrayList2<String> foundNames = new ArrayList2<>();
+		final List<String> foundNames = new ArrayList2<>();
 		for (int i = 0; i < notes.size(); i++) {
 			final int root = notes.get(i);
-			final ArrayList2<String> foundNamesForRoot = ChordNameAdder.getSuggestedChordNames(root, notes);
-			if (root != sounds[0] % 12) {
-				foundNamesForRoot.addAll(
-						foundNamesForRoot.map(chordName -> chordName + "/" + soundToSimpleName(sounds[0], true)));
-			}
+			final List<String> foundNamesForRoot = ChordNameAdder.getSuggestedChordNames(root, notes);
 			foundNames.addAll(foundNamesForRoot);
+
+			if (root != sounds[0] % 12) {
+				for (final String name : foundNamesForRoot) {
+					foundNames.add(name + "/" + soundToSimpleName(root, true));
+				}
+			}
 		}
 
 		return foundNames;
@@ -57,8 +62,7 @@ public class ChordNameSuggester {
 		return false;
 	}
 
-	public static ArrayList2<String> suggestChordNames(final Tuning tuning,
-			final HashMap2<Integer, Integer> templateFrets) {
+	public static List<String> suggestChordNames(final Tuning tuning, final Map<Integer, Integer> templateFrets) {
 		final int[] sounds = new int[templateFrets.size()];
 		int i = 0;
 		for (final Entry<Integer, Integer> stringWithFret : templateFrets.entrySet()) {
@@ -74,7 +78,7 @@ public class ChordNameSuggester {
 		Arrays.sort(sounds);
 
 		if (sounds.length == 1) {
-			return new ArrayList2<>(soundToSimpleName(sounds[0], true));
+			return asList(soundToSimpleName(sounds[0], true));
 		}
 
 		return recognizeChord(sounds);


### PR DESCRIPTION
- added catching and logging errors on initialization of the program
- fixed error when switching to next/previous arrangement while there are no arrangements
- fixed naming X3 chords (for example C3 was suggested to be just C)
- fixed selects backgrounds
- added command key available for shortcuts (needs testing by someone with a Mac)
- removed 3D preview from Mac and added a check if the audio stretching library loaded properly (if not, audio slowing/speeding up won't work)
- added some code for GPA XML import