### PR TITLE
Added phrase error notifiers for missing COUNT and END phrases.

### DIFF
--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -209,6 +209,8 @@ public class Localization {
 		NEW_VERSION_AVAILABLE_UPDATE("New version %s is available, you are on %s, download the update?"), //
 		NEW_VOCAL_PATH("New vocal path..."), //
 		NO_PHRASES_IN_ARRANGEMENT("No phrases in arrangement"), //
+		NO_COUNT_PHRASE_IN_ARRANGEMENT("No COUNT phrase in arrangement"), //
+		NO_END_PHRASE_IN_ARRANGEMENT("No END phrase in arrangement"), //
 		NO_SECTIONS_IN_ARRANGEMENT("No sections in arrangement"), //
 		NOTE_FRET_BELOW_CAPO("Note fret is below capo, for open string it should be equal"), //
 		NOTE_IN_WRONG_FHP("Note in wrong FHP"), //

--- a/src/main/java/log/charter/services/data/validation/PhrasesValidator.java
+++ b/src/main/java/log/charter/services/data/validation/PhrasesValidator.java
@@ -32,7 +32,13 @@ public class PhrasesValidator {
 
 	private void validateCountPhrases(final List<EventPoint> phrases, final int arrangementId) {
 		final List<EventPoint> countPhrases = filter(phrases, phrase -> phrase.phrase.equals("COUNT"));
-		if (countPhrases.size() <= 1) {
+		if (countPhrases.size() == 1) {
+			return;
+		}
+
+		if (countPhrases.size() < 1) {
+			final ChartPosition errorPosition = new ChartPositionOnArrangement(chartData, arrangementId, modeManager);
+			errorsTab.addError(new ChartError(Label.NO_COUNT_PHRASE_IN_ARRANGEMENT, ChartErrorSeverity.ERROR, errorPosition));
 			return;
 		}
 
@@ -43,7 +49,13 @@ public class PhrasesValidator {
 
 	private void validateEndPhrases(final List<EventPoint> phrases, final int arrangementId) {
 		final List<EventPoint> endPhrases = filter(phrases, phrase -> phrase.phrase.equals("END"));
-		if (endPhrases.size() <= 1) {
+		if (endPhrases.size() == 1) {
+			return;
+		}
+
+		if (endPhrases.size() < 1) {
+			final ChartPosition errorPosition = new ChartPositionOnArrangement(chartData, arrangementId, modeManager);
+			errorsTab.addError(new ChartError(Label.NO_END_PHRASE_IN_ARRANGEMENT, ChartErrorSeverity.ERROR, errorPosition));
 			return;
 		}
 


### PR DESCRIPTION
Changed phrase validate functions to include check for when number of END and COUNT phrases is less than 1 and return with error notifier in log.
![charter1](https://github.com/user-attachments/assets/e9cad4d3-36a8-4949-891d-62055e26a777)
![charter2](https://github.com/user-attachments/assets/a8bb7f8e-af16-4a35-8183-5890406f849d)
![charter3](https://github.com/user-attachments/assets/a80861ee-c6f0-48b4-90d1-b20a412d35bd)
