### PR TITLE
V0.22.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>log.program</groupId>
 	<artifactId>Charter</artifactId>
-	<version>0.22.37</version>
+	<version>0.22.38</version>
 	<packaging>jar</packaging>
 	<name>Charter</name>
 	<description>Charting program for guitar</description>

--- a/src/main/java/log/charter/CharterMain.java
+++ b/src/main/java/log/charter/CharterMain.java
@@ -12,8 +12,8 @@ import log.charter.services.mouseAndKeyboard.ShortcutConfig;
 import log.charter.util.RW;
 
 public class CharterMain {
-	public static final String VERSION = "0.22.37";
-	public static final String VERSION_DATE = "2026.05.15 11:00";
+	public static final String VERSION = "0.22.38";
+	public static final String VERSION_DATE = "2026.06.21 14:00";
 	public static final String TITLE = "Charter " + VERSION;
 
 	private static void deleteTempUpdateFile() {

--- a/src/main/java/log/charter/CharterMain.java
+++ b/src/main/java/log/charter/CharterMain.java
@@ -13,7 +13,7 @@ import log.charter.util.RW;
 
 public class CharterMain {
 	public static final String VERSION = "0.22.38";
-	public static final String VERSION_DATE = "2026.06.21 14:00";
+	public static final String VERSION_DATE = "2026.06.22 20:00";
 	public static final String TITLE = "Charter " + VERSION;
 
 	private static void deleteTempUpdateFile() {

--- a/src/main/java/log/charter/data/config/Config.java
+++ b/src/main/java/log/charter/data/config/Config.java
@@ -40,7 +40,6 @@ public class Config {
 	public static int zoomLvl = 100;
 	public static int stretchedMusicSpeed = 100;
 	public static boolean selectNotesByTails = false;
-	public static boolean audioFolderChosenForNewSong = false;
 	public static boolean showNoteNames = false;
 
 	private static boolean changed = false;
@@ -64,8 +63,7 @@ public class Config {
 
 		valueAccessors.put("selectNotesByTails",
 				forBoolean(v -> selectNotesByTails = v, () -> selectNotesByTails, selectNotesByTails));
-		valueAccessors.put("audioFolderChosenForNewSong", forBoolean(v -> audioFolderChosenForNewSong = v,
-				() -> audioFolderChosenForNewSong, audioFolderChosenForNewSong));
+		valueAccessors.put("showNoteNames", forBoolean(v -> showNoteNames = v, () -> showNoteNames, showNoteNames));
 
 		AudioConfig.init(valueAccessors, "audio");
 		DebugConfig.init(valueAccessors, "debug");

--- a/src/main/java/log/charter/data/config/Config.java
+++ b/src/main/java/log/charter/data/config/Config.java
@@ -13,6 +13,7 @@ import java.util.Map.Entry;
 
 import log.charter.data.config.values.AudioConfig;
 import log.charter.data.config.values.DebugConfig;
+import log.charter.data.config.values.GPConfig;
 import log.charter.data.config.values.GridConfig;
 import log.charter.data.config.values.InstrumentConfig;
 import log.charter.data.config.values.NoteDistanceConfig;
@@ -67,6 +68,7 @@ public class Config {
 
 		AudioConfig.init(valueAccessors, "audio");
 		DebugConfig.init(valueAccessors, "debug");
+		GPConfig.init(valueAccessors, "gp");
 		GridConfig.init(valueAccessors, "grid");
 		InstrumentConfig.init(valueAccessors, "instrument");
 		NoteDistanceConfig.init(valueAccessors, "noteDistance");

--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -178,9 +178,11 @@ public class Localization {
 		FRET_DIFFERENT_THAN_IN_ARPEGGIO_HANDSHAPE(
 				"Fret in sound is different than fret in hand shape under it on the same string"), //
 		FRETS("Frets"), //
+		GENERATE_FHP("Generate FHP"), //
 		GO_PLAY_ALONG("GoPlayAlong file"), //
 		GUITAR_ARRANGEMENT("Guitar arrangement"), //
 		GUITAR_EVENT_POINT_PANE("Event point"), //
+		GP_FILE_IMPORT_OPTIONS("GP file import options"), //
 		GP_FILES_FOLDER("GP files folder"), //
 		GRAPHIC_CONFIG_PANE("Graphic config"), //
 		GRID_TYPE_BEAT("Beat"), //
@@ -194,6 +196,7 @@ public class Localization {
 		HIGH_PASS_SETTINGS("High pass settings"), //
 		HIGH_PASS_TOOLTIP(
 				"<html>High pass filter filters out frequencies below given value<br/>Right click for settings</html>"), //
+		IMPORT_TEMPO_MAP("Import tempo map"), //
 		IMPORTING_AUDIO("Importing audio"), //
 		IMPORT_AUDIO_AS_STEM("Import audio as stem?"), //
 		IMPORT_LRC_VOCALS("Import LRC vocals file"), //
@@ -408,6 +411,8 @@ public class Localization {
 		SIZE_L("L"), //
 		SIZE_XL("XL"), //
 		SIZE_XXL("XXL"), //
+		SLIDE_IN_SIZE("Slide in size"), //
+		SLIDE_OUT_SIZE("Slide out size"), //
 		SONG_FOLDER_AUDIO_FOLDER("Use audio file folder"), //
 		SONG_FOLDER_GP_FOLDER("Use GP file folder"), //
 		SONG_FOLDER_IN_CHARTS_DIR("Create new folder in charts directory"), //
@@ -692,7 +697,6 @@ public class Localization {
 		GENERATING_SLOWED_SOUND("Playback speed added to queue"), //
 		GP_FILE("GP file (.gp3, .gp4, .gp5, .gp)"), //
 		GP7_FILE("GP7+ file (.gp)"), //
-		GP_IMPORT_TEMPO_MAP("GP import tempo map"), //
 		MOVE_BACKWARD("Move backward"), //
 		MOVE_FORWARD("Move forward"), //
 		LOADING("Please wait, loading..."), //
@@ -723,7 +727,6 @@ public class Localization {
 		UNSAVED_CHANGES_POPUP("Unsaved changes"), //
 		UNSAVED_CHANGES_MESSAGE("You have unsaved changes. Do you want to save?"), //
 		UNSUPPORTED_FILE_TYPE("This file type is not supported"), //
-		USE_TEMPO_MAP_FROM_IMPORT("Do you want to use the tempo map from the imported project?"), //
 		VALUE_CANT_BE_EMPTY("Value must not be empty"), //
 		VALUE_MUST_BE_GE("Value must be greater or equal to %s"), //
 		VALUE_MUST_BE_LE("Value must be lesser or equal to %s"), //

--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -166,6 +166,8 @@ public class Localization {
 		FIRST_BEAT_BEFORE_10_SECONDS("First beat is set before 10 seconds have passed"), //
 		FIRST_FINGER_ON_NOT_LOWEST_FRET(
 				"First finger set on fret that's not lowest non-open fret in template [%d] - string %d"), //
+		FOLDER_EXISTS("Given folder already exists"), //
+		FOLDER_EXISTS_MSG("Do you want to use existing folder?"), //
 		FORCE_ARPEGGIO_IN_RS("in RS"), //
 		FPS("FPS"), //
 		FRET("Fret"), //
@@ -405,6 +407,11 @@ public class Localization {
 		SIZE_L("L"), //
 		SIZE_XL("XL"), //
 		SIZE_XXL("XXL"), //
+		SONG_FOLDER_AUDIO_FOLDER("Use audio file folder"), //
+		SONG_FOLDER_GP_FOLDER("Use GP file folder"), //
+		SONG_FOLDER_IN_CHARTS_DIR("Create new folder in charts directory"), //
+		SONG_FOLDER_OTHER("Select other folder"), //
+		SONG_FOLDER_XML_FOLDER("Use XML file folder"), //
 		SONG_OPTIONS("Song options"), //
 		SONGS_FOLDER("Songs folder"), //
 		SOUND_DELAY("Sound delay (ms)"), //

--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -421,6 +421,8 @@ public class Localization {
 		SONG_OPTIONS("Song options"), //
 		SONGS_FOLDER("Songs folder"), //
 		SOUND_DELAY("Sound delay (ms)"), //
+		SOUND_PAST_LAST_PHRASE("Sound past last phrase"), //
+		SOUND_SPLIT_BY_PHRASE("Sound split by phrase or linked to a sound in next phrase"), //
 		SOUND_WITH_TREMOLO_OR_VIBRATO_WITHOUT_TAIL("Sound has tremolo or vibrato and no sustain"), //
 		SPECIAL_PASTE("Special paste"), //
 		SPEED_DECREASE("Decrease speed"), //

--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -95,6 +95,7 @@ public class Localization {
 		CHARTER_WIKI("Charter wiki"), //
 		CHOOSE_COLOR_FOR("Choose color for %s"), //
 		CHORD_WITH_NOTE_TAILS("Chord with note tails without any techniques"), //
+		CHORD_WITH_SPLIT_AND_ONLY_BOX("Chord has both Split and Only box flags marked"), //
 		CONFIG("Config"), //
 		CONFIG_AUDIO("Audio"), //
 		CONFIG_DISPLAY("Display"), //

--- a/src/main/java/log/charter/data/config/Localization.java
+++ b/src/main/java/log/charter/data/config/Localization.java
@@ -415,6 +415,7 @@ public class Localization {
 		SONG_OPTIONS("Song options"), //
 		SONGS_FOLDER("Songs folder"), //
 		SOUND_DELAY("Sound delay (ms)"), //
+		SOUND_WITH_TREMOLO_OR_VIBRATO_WITHOUT_TAIL("Sound has tremolo or vibrato and no sustain"), //
 		SPECIAL_PASTE("Special paste"), //
 		SPEED_DECREASE("Decrease speed"), //
 		SPEED_DECREASE_FAST("Decrease speed fast"), //

--- a/src/main/java/log/charter/data/config/values/GPConfig.java
+++ b/src/main/java/log/charter/data/config/values/GPConfig.java
@@ -1,0 +1,20 @@
+package log.charter.data.config.values;
+
+import static log.charter.data.config.values.accessors.BooleanValueAccessor.forBoolean;
+import static log.charter.data.config.values.accessors.IntValueAccessor.forInteger;
+
+import java.util.Map;
+
+import log.charter.data.config.values.accessors.ValueAccessor;
+
+public class GPConfig {
+	public static boolean generateFHP = false;
+	public static int slideInSize = 2;
+	public static int slideOutSize = 5;
+
+	public static void init(final Map<String, ValueAccessor> valueAccessors, final String name) {
+		valueAccessors.put(name + ".generateFHP", forBoolean(v -> generateFHP = v, () -> generateFHP, generateFHP));
+		valueAccessors.put(name + ".slideInSize", forInteger(v -> slideInSize = v, () -> slideInSize, slideInSize));
+		valueAccessors.put(name + ".slideOutSize", forInteger(v -> slideOutSize = v, () -> slideOutSize, slideOutSize));
+	}
+}

--- a/src/main/java/log/charter/gui/chartPanelDrawers/data/HighlightData.java
+++ b/src/main/java/log/charter/gui/chartPanelDrawers/data/HighlightData.java
@@ -298,15 +298,15 @@ public class HighlightData {
 
 	private static HighlightData getDraggedPositions(final double time, final ChartData chartData,
 			final SelectionManager selectionManager, final MouseButtonPressData press, final int x) {
-		if (press.highlight.type == PositionType.NONE || press.highlight.type == BEAT) {
+		if (press.highlight.type == PositionType.NONE || press.highlight.type == BEAT
+				|| !press.highlight.existingPosition) {
 			return null;
 		}
 
 		List<Selection<IVirtualConstantPosition>> selectedPositions = selectionManager
 				.getSelected(press.highlight.type);
 
-		if (press.highlight.existingPosition//
-				&& !contains(selectedPositions, selection -> selection.id == press.highlight.id)) {
+		if (!contains(selectedPositions, selection -> selection.id == press.highlight.id)) {
 			selectionManager.clear();
 			selectionManager.addSelection(press.highlight.type, press.highlight.id);
 			selectedPositions = selectionManager.getSelected(press.highlight.type);

--- a/src/main/java/log/charter/gui/chartPanelDrawers/instruments/guitar/GuitarEventPointsDrawer.java
+++ b/src/main/java/log/charter/gui/chartPanelDrawers/instruments/guitar/GuitarEventPointsDrawer.java
@@ -86,7 +86,9 @@ public class GuitarEventPointsDrawer {
 			final int x = positionToX(eventPoint.position(frameData.beats), frameData.time);
 			final boolean highlighted = i == highlightId;
 			if (x < 0) {
-				highwayDrawer.addEvents(eventPoint, x, highlighted);
+				if (x > -1000) {
+					highwayDrawer.addEvents(eventPoint, x, highlighted);
+				}
 				continue;
 			}
 			if (x > panelWidth) {

--- a/src/main/java/log/charter/gui/components/containers/SongFolderSelectPane.java
+++ b/src/main/java/log/charter/gui/components/containers/SongFolderSelectPane.java
@@ -1,78 +1,205 @@
 package log.charter.gui.components.containers;
 
+import static log.charter.data.config.GraphicalConfig.inputSize;
+import static log.charter.gui.components.utils.ComponentUtils.setDefaultFontSize;
+import static log.charter.util.FileUtils.cleanFileName;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import javax.swing.ButtonGroup;
+import javax.swing.JButton;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
-import log.charter.data.config.Config;
 import log.charter.data.config.Localization.Label;
+import log.charter.data.config.values.PathsConfig;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.components.simple.FieldWithLabel;
 import log.charter.gui.components.simple.FieldWithLabel.LabelPosition;
+import log.charter.gui.components.utils.RowedPosition;
+import log.charter.util.FileChooseUtils;
+import log.charter.util.collections.Pair;
 
-public class SongFolderSelectPane extends ParamsPane {
+public class SongFolderSelectPane extends RowedDialog {
+	public enum FolderSelectedType {
+		AUDIO, CHARTS_DIR, OTHER_FOLDER, GP, XML_FILE
+	}
+
 	private static final long serialVersionUID = 8709914106065183780L;
 
-	private boolean audioFolderChosen = Config.audioFolderChosenForNewSong;
-	private String folderName;
+	private final String audioDir;
+	private final String audioFolder;
+	private final String defaultFolderName;
+	private final String gpDir;
+	private final String gpFolder;
+	private final String xmlDir;
+	private final String xmlFolder;
 
-	public SongFolderSelectPane(final CharterFrame charterFrame, final String songsDirectory, final String audioFolder,
-			final String defaultFolderName) {
-		super(charterFrame, Label.SONG_FOLDER_SELECT, 700);
+	private final JTextField folderPathInput;
+	private final JTextField folderNameInput;
+	private final JButton pathSelectButton;
 
-		final ButtonGroup group = new ButtonGroup();
-		final JTextField folderNameInput = new JTextField(200);
+	private FolderSelectedType folderType;
 
-		final String audioFolderOptionLabel = String.format(Label.SONG_FOLDER_AUDIO_FILE_FOLDER.label(), audioFolder);
-		final JRadioButton audioFolderOptionButton = new JRadioButton();
-		audioFolderOptionButton.setSelected(audioFolderChosen);
-		audioFolderOptionButton.addChangeListener(e -> {
-			if (audioFolderOptionButton.isSelected()) {
-				folderNameInput.setEnabled(false);
-			}
-		});
-		group.add(audioFolderOptionButton);
-		final FieldWithLabel<JRadioButton> audioFolderOption = new FieldWithLabel<>(audioFolderOptionLabel, 500, 20, 20,
-				audioFolderOptionButton, LabelPosition.RIGHT_CLOSE);
-		audioFolderOption.setLocation(20, getY(0));
-		this.add(audioFolderOption);
+	private void enableInputsAndSetValues() {
+		final String path = switch (folderType) {
+			case AUDIO -> audioDir;
+			case GP -> gpDir;
+			case XML_FILE -> xmlDir;
+			default -> PathsConfig.songsPath;
+		};
+		folderPathInput.setText(path);
+		folderPathInput.setEnabled(folderType == FolderSelectedType.OTHER_FOLDER);
 
-		final String newFolderOptionLabel = String.format(Label.SONG_FOLDER_CREATE_NEW.label(), songsDirectory);
-		final JRadioButton newFolderOptionButton = new JRadioButton();
-		newFolderOptionButton.setSelected(!audioFolderChosen);
-		newFolderOptionButton.addChangeListener(e -> {
-			if (newFolderOptionButton.isSelected()) {
-				folderNameInput.setEnabled(true);
-			}
-		});
-		group.add(newFolderOptionButton);
-		final FieldWithLabel<JRadioButton> newFolderOption = new FieldWithLabel<>(newFolderOptionLabel, 500, 20, 20,
-				newFolderOptionButton, LabelPosition.RIGHT_CLOSE);
-		newFolderOption.setLocation(20, getY(1));
-		this.add(newFolderOption);
+		final String folder = switch (folderType) {
+			case AUDIO -> audioFolder;
+			case GP -> gpFolder;
+			case XML_FILE -> xmlFolder;
+			default -> defaultFolderName;
+		};
+		folderNameInput.setText(folder);
+		folderNameInput.setEnabled(
+				folderType == FolderSelectedType.CHARTS_DIR || folderType == FolderSelectedType.OTHER_FOLDER);
 
-		folderNameInput.setText(defaultFolderName);
-		folderNameInput.setLocation(40, getY(2));
-		folderNameInput.setSize(500, 20);
+		pathSelectButton.setVisible(folderType == FolderSelectedType.OTHER_FOLDER);
+	}
+
+	public SongFolderSelectPane(final CharterFrame charterFrame, final File audioFolderPath,
+			final String defaultFolderName, final String gpFolderPath, final File xmlFolderPath,
+			final FolderSelectedType defaultType) {
+		super(charterFrame, Label.SONG_FOLDER_SELECT);
+
+		audioDir = audioFolderPath.getParentFile().getAbsolutePath();
+		audioFolder = audioFolderPath.getName();
+		this.defaultFolderName = defaultFolderName;
+
+		if (gpFolderPath != null) {
+			final File gpFolderFile = new File(gpFolderPath);
+			gpDir = gpFolderFile.getParentFile().getAbsolutePath();
+			gpFolder = gpFolderFile.getName();
+		} else {
+			gpDir = null;
+			gpFolder = null;
+		}
+		if (xmlFolderPath != null) {
+			xmlDir = xmlFolderPath.getParentFile().getAbsolutePath();
+			xmlFolder = xmlFolderPath.getName();
+		} else {
+			xmlDir = null;
+			xmlFolder = null;
+		}
+
+		folderPathInput = new JTextField(400);
+		folderNameInput = new JTextField(200);
+
+		final RowedPosition position = new RowedPosition(inputSize * 3 / 2, panel.sizes);
+		final Map<FolderSelectedType, JRadioButton> buttonsPerType = addButtons(position);
+
 		this.add(folderNameInput);
+		setDefaultFontSize(folderPathInput);
+		panel.addWithSettingSize(folderPathInput, position, 400);
+		position.newRow();
 
-		this.setOnFinish(() -> {
-			audioFolderChosen = audioFolderOptionButton.isSelected();
-			folderName = folderNameInput.getText();
-		}, this::cancel);
-		addDefaultFinish(4);
+		setDefaultFontSize(folderNameInput);
+		panel.addWithSettingSize(folderNameInput, position, 200);
+		pathSelectButton = addFolderSelectButton(position);
+		position.newRow();
+		position.newRow();
+
+		if (buttonsPerType.containsKey(defaultType)) {
+			buttonsPerType.get(defaultType).setSelected(true);
+		} else {
+			buttonsPerType.get(FolderSelectedType.CHARTS_DIR).setSelected(true);
+		}
+
+		addDefaultFinish(position.y(), null, SaverWithStatus.defaultFor(this::cancel), true);
 	}
 
-	public boolean isAudioFolderChosen() {
-		return audioFolderChosen;
+	private Map<FolderSelectedType, JRadioButton> addButtons(final RowedPosition position) {
+		final Map<FolderSelectedType, JRadioButton> buttonsPerType = new HashMap<>();
+		final ButtonGroup group = new ButtonGroup();
+
+		final List<Pair<Label, FolderSelectedType>> buttonData = new ArrayList<>();
+		buttonData.add(new Pair<>(Label.SONG_FOLDER_AUDIO_FOLDER, FolderSelectedType.AUDIO));
+		if (gpDir != null) {
+			buttonData.add(new Pair<>(Label.SONG_FOLDER_GP_FOLDER, FolderSelectedType.GP));
+		}
+		if (xmlDir != null) {
+			buttonData.add(new Pair<>(Label.SONG_FOLDER_XML_FOLDER, FolderSelectedType.XML_FILE));
+		}
+		buttonData.add(new Pair<>(Label.SONG_FOLDER_IN_CHARTS_DIR, FolderSelectedType.CHARTS_DIR));
+		buttonData.add(new Pair<>(Label.SONG_FOLDER_OTHER, FolderSelectedType.OTHER_FOLDER));
+		for (final Pair<Label, FolderSelectedType> data : buttonData) {
+			final FieldWithLabel<JRadioButton> field = addOption(position, group, data.a, data.b);
+			buttonsPerType.put(data.b, field.field);
+		}
+
+		return buttonsPerType;
 	}
 
-	public String getFolderName() {
-		return folderName;
+	private FieldWithLabel<JRadioButton> addOption(final RowedPosition position, final ButtonGroup group,
+			final Label label, final FolderSelectedType type) {
+		final JRadioButton radioButton = new JRadioButton();
+		radioButton.setSelected(false);
+		radioButton.addChangeListener(e -> {
+			if (radioButton.isSelected()) {
+				folderType = type;
+				enableInputsAndSetValues();
+			}
+		});
+		group.add(radioButton);
+		final FieldWithLabel<JRadioButton> audioFolderOption = new FieldWithLabel<>(label, 0, inputSize, inputSize,
+				radioButton, LabelPosition.RIGHT_CLOSE);
+
+		panel.add(audioFolderOption, position);
+		position.newRow();
+
+		return audioFolderOption;
+	}
+
+	private void selectFolder() {
+		File currentFolder = getFolder();
+		if (currentFolder == null) {
+			currentFolder = new File(PathsConfig.songsPath);
+		}
+		final File newFolder = FileChooseUtils.chooseDirectory(panel, currentFolder.getAbsolutePath());
+		if (newFolder == null) {
+			return;
+		}
+
+		folderPathInput.setText(newFolder.getParentFile().getAbsolutePath());
+		folderNameInput.setText(newFolder.getName());
+	}
+
+	private JButton addFolderSelectButton(final RowedPosition position) {
+		final JButton button = new JButton(Label.SELECT_FOLDER.label());
+		button.setSize(inputSize * 5, inputSize);
+		setDefaultFontSize(button);
+		button.addActionListener(e -> selectFolder());
+		panel.add(button, position);
+
+		return button;
+	}
+
+	public File getFolder() {
+		final String path = folderPathInput.getText();
+		final String folder = folderNameInput.getText();
+		if (folderType == null || path == null || path.isBlank() || folder == null || folder.isBlank()) {
+			return null;
+		}
+
+		return new File(path, cleanFileName(folder));
+	}
+
+	public FolderSelectedType getFolderType() {
+		return folderType;
 	}
 
 	private void cancel() {
-		audioFolderChosen = false;
-		folderName = null;
+		folderType = null;
 	}
 }

--- a/src/main/java/log/charter/gui/components/simple/FieldWithLabel.java
+++ b/src/main/java/log/charter/gui/components/simple/FieldWithLabel.java
@@ -27,6 +27,26 @@ public class FieldWithLabel<T extends Component> extends Container {
 
 	private static final long serialVersionUID = 1L;
 
+	private static int getTextWidth(final JLabel label) {
+		final String text = label.getText();
+		if (text == null) {
+			return 0;
+		}
+
+		final Graphics2D gs = (Graphics2D) label.getGraphics();
+
+		final FontMetrics fm = label.getFontMetrics(label.getFont());
+
+		if (gs == null) {
+			return fm.stringWidth(text);
+		}
+
+		final Rectangle2D rect = fm.getStringBounds(text, gs);
+		final double w = rect.getWidth();
+		gs.dispose();
+		return (int) w;
+	}
+
 	public ColorLabel backgroundColor = null;
 
 	public final LabelPosition labelPosition;
@@ -51,34 +71,34 @@ public class FieldWithLabel<T extends Component> extends Container {
 			case LEFT:
 				this.label = addLabel(label, 0, labelWidth, height, SwingConstants.LEFT);
 				this.addField(field, labelWidth + 5, inputWidth, height);
-				totalSize = labelWidth + inputWidth + 5;
+				totalSize = this.label.getWidth() + inputWidth + 5;
 				break;
 			case LEFT_CLOSE:
 				this.label = addLabel(label, 0, labelWidth, height, SwingConstants.RIGHT);
 				this.addField(field, labelWidth + 5, inputWidth, height);
-				totalSize = labelWidth + inputWidth + 5;
+				totalSize = this.label.getWidth() + inputWidth + 5;
 				break;
 			case LEFT_PACKED:
 				this.label = addLabel(label, 0, 999, height, SwingConstants.LEFT);
 				labelWidth += getTextWidth();
 				this.label.setSize(labelWidth, height);
 				this.addField(field, labelWidth, inputWidth, height);
-				totalSize = labelWidth + inputWidth;
+				totalSize = this.label.getWidth() + inputWidth;
 				break;
 			case RIGHT_PACKED:
 				this.addField(field, 0, inputWidth, height);
 				this.label = addLabel(label, inputWidth + labelWidth, 999, height, SwingConstants.LEFT);
-				totalSize = inputWidth + labelWidth + getTextWidth();
+				totalSize = inputWidth + this.label.getWidth() + getTextWidth();
 				break;
 			case RIGHT_CLOSE:
 				this.addField(field, 0, inputWidth, height);
 				this.label = addLabel(label, inputWidth + 2, labelWidth, height, SwingConstants.LEFT);
-				totalSize = labelWidth + inputWidth + 2;
+				totalSize = this.label.getWidth() + inputWidth + 2;
 				break;
 			case RIGHT:
 				this.addField(field, 0, inputWidth, height);
 				this.label = addLabel(label, inputWidth + 2, labelWidth, height, SwingConstants.RIGHT);
-				totalSize = labelWidth + inputWidth + 2;
+				totalSize = this.label.getWidth() + inputWidth + 2;
 				break;
 			default:
 				throw new RuntimeException("Unknown label position " + labelPosition);
@@ -118,30 +138,17 @@ public class FieldWithLabel<T extends Component> extends Container {
 	}
 
 	public int getTextWidth() {
-		final String text = label.getText();
-		if (text == null) {
-			return 0;
-		}
-
-		final Graphics2D gs = (Graphics2D) label.getGraphics();
-
-		final FontMetrics fm = label.getFontMetrics(label.getFont());
-
-		if (gs == null) {
-			return fm.stringWidth(text);
-		}
-
-		final Rectangle2D rect = fm.getStringBounds(text, gs);
-		final double w = rect.getWidth();
-		gs.dispose();
-		return (int) w;
+		return getTextWidth(label);
 	}
 
-	private JLabel addLabel(final String label, final int x, final int w, final int h, final int labelAlignment) {
+	private JLabel addLabel(final String label, final int x, int w, final int h, final int labelAlignment) {
 		final JLabel labelComponent = new JLabel(label, labelAlignment);
 		labelComponent.setAlignmentY(CENTER_ALIGNMENT);
 		setDefaultFontSize(labelComponent);
 
+		if (w == 0) {
+			w = getTextWidth(labelComponent);
+		}
 		setComponentBounds(labelComponent, x, 0, w, h);
 		this.add(labelComponent);
 

--- a/src/main/java/log/charter/gui/components/tabs/selectionEditor/GuitarSoundSelectionEditor.java
+++ b/src/main/java/log/charter/gui/components/tabs/selectionEditor/GuitarSoundSelectionEditor.java
@@ -538,7 +538,7 @@ public class GuitarSoundSelectionEditor extends ChordTemplateEditor {
 		setCurrentValuesInInputs();
 	}
 
-	private void setSlideForPartialChords(final List<ChordOrNote> selected) {
+	private void setSlide(final List<ChordOrNote> selected) {
 		final List<CommonNote> selectedNotesWithoutOpenStrings = selected.stream()//
 				.flatMap(sound -> sound.notesWithFrets(chartData.currentChordTemplates()))//
 				.filter(n -> n.fret() > 0 && parent.isEdited(n.string()))//
@@ -551,29 +551,6 @@ public class GuitarSoundSelectionEditor extends ChordTemplateEditor {
 		unpitchedSlide.field.setSelected(slideValue.b);
 	}
 
-	private void setSlideForFullChords(final List<ChordOrNote> selected) {
-		final Integer slideFretValue = getSingleValue(selected, sound -> {
-			if (sound.isNote()) {
-				return sound.note().slideTo;
-			}
-
-			Integer slideTo = null;
-			for (final Entry<Integer, ChordNote> chordNote : sound.chord().chordNotes.entrySet()) {
-				if (chordNote.getValue().slideTo == null) {
-					continue;
-				}
-
-				slideTo = slideTo == null ? chordNote.getValue().slideTo//
-						: min(slideTo, chordNote.getValue().slideTo);
-			}
-
-			return slideTo;
-		}, null);
-
-		slideFret.field.setTextWithoutEvent(slideFretValue == null ? "" : (slideFretValue + ""));
-
-	}
-
 	private void updateStringSelectionDependentValues() {
 		final List<ChordOrNote> selected = selectionManager.getSelectedElements(PositionType.GUITAR_NOTE);
 
@@ -583,12 +560,7 @@ public class GuitarSoundSelectionEditor extends ChordTemplateEditor {
 		linkNext.field.setSelected(getValueFromSelectedStrings(n -> n.linkNext, n -> n.linkNext, false, selected));
 		vibrato.field.setSelected(getValueFromSelectedStrings(n -> n.vibrato, n -> n.vibrato, false, selected));
 		tremolo.field.setSelected(getValueFromSelectedStrings(n -> n.tremolo, n -> n.tremolo, false, selected));
-
-		if (parent.allStringsEdited()) {
-			setSlideForFullChords(selected);
-		} else {
-			setSlideForPartialChords(selected);
-		}
+		setSlide(selected);
 	}
 
 	public void selectionChanged(final ISelectionAccessor<ChordOrNote> selectedChordOrNotesAccessor,

--- a/src/main/java/log/charter/gui/components/tabs/selectionEditor/chords/ChordTemplateEditor.java
+++ b/src/main/java/log/charter/gui/components/tabs/selectionEditor/chords/ChordTemplateEditor.java
@@ -210,6 +210,7 @@ public class ChordTemplateEditor implements ChordTemplateEditorInterface, MouseL
 		checkBox.setSelected(Config.showNoteNames);
 		checkBox.addActionListener(e -> {
 			Config.showNoteNames = checkBox.isSelected();
+			Config.markChanged();
 			chordTemplatePreview.repaint();
 		});
 

--- a/src/main/java/log/charter/gui/panes/imports/ArrangementImportOptions.java
+++ b/src/main/java/log/charter/gui/panes/imports/ArrangementImportOptions.java
@@ -9,6 +9,7 @@ import java.util.List;
 import log.charter.data.ChartData;
 import log.charter.data.config.Localization.Label;
 import log.charter.data.song.Arrangement;
+import log.charter.data.song.Level;
 import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.components.containers.ParamsPane;
@@ -145,7 +146,12 @@ public class ArrangementImportOptions extends ParamsPane {
 			final Arrangement arrangementToAdd = imported.arrangements.get(i);
 			if (createFHP) {
 				createFHPs(data.beats(), arrangementToAdd);
+			} else {
+				for (final Level level : arrangementToAdd.levels) {
+					level.fhps.clear();
+				}
 			}
+
 			if (setting.arrangementId != null) {
 				data.songChart.arrangements.set(setting.arrangementId, arrangementToAdd);
 			} else {

--- a/src/main/java/log/charter/gui/panes/imports/ArrangementImportOptions.java
+++ b/src/main/java/log/charter/gui/panes/imports/ArrangementImportOptions.java
@@ -15,6 +15,7 @@ import log.charter.gui.CharterFrame;
 import log.charter.gui.components.containers.ParamsPane;
 import log.charter.gui.components.simple.CharterSelect;
 import log.charter.gui.menuHandlers.CharterMenuBar;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.services.data.fixers.ArrangementFixer;
 
 public class ArrangementImportOptions extends ParamsPane {
@@ -47,26 +48,23 @@ public class ArrangementImportOptions extends ParamsPane {
 	private final CharterMenuBar charterMenuBar;
 	private final ChartData data;
 	private final SongChart imported;
+	private final GPFileImportOptions importOptions;
 
-	private boolean createFHP = false;
 	private final ArrangementImportSetting[] arrangementImportSettings;
 	private final List<ArrangementImportSetting> arrangementImportSettingsOptions;
 
 	public ArrangementImportOptions(final CharterFrame frame, final ArrangementFixer arrangementFixer,
 			final CharterMenuBar charterMenuBar, final ChartData data, final SongChart imported,
-			final List<String> trackNames) {
+			final List<String> trackNames, final GPFileImportOptions importOptions) {
 		super(frame, Label.ARRANGEMENT_IMPORT_OPTIONS, 450);
 
 		this.arrangementFixer = arrangementFixer;
 		this.charterMenuBar = charterMenuBar;
 		this.data = data;
 		this.imported = imported;
+		this.importOptions = importOptions;
 
 		int row = 0;
-		addCreateFHPCheckbox(row);
-
-		row++;
-
 		arrangementImportSettings = new ArrangementImportSetting[imported.arrangements.size()];
 		arrangementImportSettingsOptions = prepareArrangementImportSettingsOptions();
 
@@ -84,11 +82,6 @@ public class ArrangementImportOptions extends ParamsPane {
 
 		setOnFinish(this::saveAndExit, null);
 		addDefaultFinish(row);
-	}
-
-	private void addCreateFHPCheckbox(final int row) {
-		addConfigCheckbox(row, 10, createFHP, newCreateFHP -> createFHP = newCreateFHP);
-		addLabel(row, 45, Label.CREATE_FHP_AUTOMATICALLY, 0);
 	}
 
 	private List<ArrangementImportSetting> prepareArrangementImportSettingsOptions() {
@@ -144,7 +137,7 @@ public class ArrangementImportOptions extends ParamsPane {
 			}
 
 			final Arrangement arrangementToAdd = imported.arrangements.get(i);
-			if (createFHP) {
+			if (importOptions.generateFHP) {
 				createFHPs(data.beats(), arrangementToAdd);
 			} else {
 				for (final Level level : arrangementToAdd.levels) {

--- a/src/main/java/log/charter/gui/panes/shortcuts/ShortcutConfigGroup.java
+++ b/src/main/java/log/charter/gui/panes/shortcuts/ShortcutConfigGroup.java
@@ -59,8 +59,6 @@ public enum ShortcutConfigGroup {
 			Action.DECREASE_LENGTH_FAST, //
 			Action.INCREASE_LENGTH, //
 			Action.INCREASE_LENGTH_FAST, //
-			Action.SELECT_ALL, //
-			Action.SELECT_ALL, //
 			Action.TOGGLE_ANCHOR, //
 			Action.BEAT_ADD, //
 			Action.BEAT_REMOVE, //

--- a/src/main/java/log/charter/gui/panes/shortcuts/ShortcutConfigPane.java
+++ b/src/main/java/log/charter/gui/panes/shortcuts/ShortcutConfigPane.java
@@ -55,7 +55,7 @@ public final class ShortcutConfigPane extends ParamsPane implements ComponentLis
 	private final JButton cancelButton;
 
 	public ShortcutConfigPane(final CharterMenuBar charterMenuBar, final CharterFrame frame) {
-		super(frame, Label.SHORTCUT_CONFIG_PANE, new PaneSizesBuilder(inputSize * 21).build());
+		super(frame, Label.SHORTCUT_CONFIG_PANE, new PaneSizesBuilder(inputSize * 23).build());
 		this.charterMenuBar = charterMenuBar;
 
 		setDefaultShortcutsButton = new JButton(Label.SHORTCUTS_SET_CHARTER_DEFAULT.label());
@@ -99,7 +99,7 @@ public final class ShortcutConfigPane extends ParamsPane implements ComponentLis
 	private ScrollableRowedPanel makePanel() {
 		final int rows = ShortcutConfigGroup.groups.stream()
 				.collect(Collectors.summingInt(group -> 1 + group.actions.size()));
-		final ScrollableRowedPanel panel = new ScrollableRowedPanel(inputSize * 20, rows);
+		final ScrollableRowedPanel panel = new ScrollableRowedPanel(inputSize * 22, rows);
 		panel.getVerticalScrollBar().setUnitIncrement(20);
 
 		return panel;
@@ -108,14 +108,14 @@ public final class ShortcutConfigPane extends ParamsPane implements ComponentLis
 	private void addLabel(final Label label, final int row) {
 		final JLabel groupLabel = new JLabel(label.label(), JLabel.CENTER);
 		groupLabel.setFont(new Font(Font.DIALOG, Font.BOLD, inputSize));
-		panel.addWithYOffset(groupLabel, inputSize, row, -inputSize / 4, inputSize * 18, inputSize * 3 / 2);
+		panel.addWithYOffset(groupLabel, inputSize, row, -inputSize / 4, inputSize * 20, inputSize * 3 / 2);
 	}
 
 	private void addEditFor(final Action action, final int row) {
 		final ShortcutEditor editor = new ShortcutEditor(this, action);
-		final FieldWithLabel<ShortcutEditor> fieldWithLabel = new FieldWithLabel<>(action.label, inputSize * 10,
+		final FieldWithLabel<ShortcutEditor> fieldWithLabel = new FieldWithLabel<>(action.label, inputSize * 12,
 				inputSize * 15 / 2, inputSize, editor, LabelPosition.LEFT);
-		panel.add(fieldWithLabel, inputSize, row, inputSize * 18, inputSize);
+		panel.add(fieldWithLabel, inputSize, row, inputSize * 20, inputSize);
 
 		editors.put(action, fieldWithLabel.field);
 	}
@@ -234,8 +234,9 @@ public final class ShortcutConfigPane extends ParamsPane implements ComponentLis
 		final int scrollTop = sizes.getY(2);
 		final int scrollBottom = h - inputSize * 5 / 2;
 
-		if (w > inputSize * 21) {
-			setComponentBounds(panel, middleX - inputSize * 10, scrollTop, inputSize * 21, scrollBottom - scrollTop);
+		if (w > inputSize * 23) {
+			setComponentBounds(panel, middleX - inputSize * 23 / 2, scrollTop, inputSize * 23,
+					scrollBottom - scrollTop);
 		} else {
 			setComponentBounds(panel, 0, scrollTop, w, scrollBottom - scrollTop);
 		}

--- a/src/main/java/log/charter/gui/panes/songEdits/AddSilenceAtTheEndPane.java
+++ b/src/main/java/log/charter/gui/panes/songEdits/AddSilenceAtTheEndPane.java
@@ -122,7 +122,7 @@ public class AddSilenceAtTheEndPane extends RowedDialog {
 	}
 
 	private void addSilence(final double time) {
-		final AudioData songMusicData = projectAudioHandler.getAudio();
+		final AudioData songMusicData = projectAudioHandler.getMainAudio();
 		final AudioData silenceMusicData = AudioGenerator.generateSilence(time, songMusicData.format.getSampleRate(),
 				songMusicData.format.getChannels(), songMusicData.format.getSampleSizeInBits() / 8);
 		try {
@@ -144,7 +144,7 @@ public class AddSilenceAtTheEndPane extends RowedDialog {
 	}
 
 	private void cutAudio(final double length) {
-		final AudioData editedAudio = projectAudioHandler.getAudio().cutToLength(length);
+		final AudioData editedAudio = projectAudioHandler.getMainAudio().cutToLength(length);
 		projectAudioHandler.changeAudio(editedAudio);
 	}
 

--- a/src/main/java/log/charter/gui/panes/songEdits/AddSilenceInTheBeginningPane.java
+++ b/src/main/java/log/charter/gui/panes/songEdits/AddSilenceInTheBeginningPane.java
@@ -91,7 +91,7 @@ public class AddSilenceInTheBeginningPane extends ParamsPane {
 	}
 
 	private void addSilence(final double time) {
-		final AudioData songMusicData = projectAudioHandler.getAudio();
+		final AudioData songMusicData = projectAudioHandler.getMainAudio();
 		final AudioData silenceMusicData = AudioGenerator.generateSilence(time, songMusicData.format.getSampleRate(),
 				songMusicData.format.getChannels(), songMusicData.format.getSampleSizeInBits() / 8);
 		try {
@@ -107,7 +107,7 @@ public class AddSilenceInTheBeginningPane extends ParamsPane {
 	}
 
 	private void removeAudio(final double time) {
-		final AudioData editedAudio = projectAudioHandler.getAudio().removeFromStart(time);
+		final AudioData editedAudio = projectAudioHandler.getMainAudio().removeFromStart(time);
 
 		projectAudioHandler.changeAudio(editedAudio);
 		projectAudioHandler.changeStemsOffset(-time);

--- a/src/main/java/log/charter/gui/panes/songEdits/ChangeSongPitchPane.java
+++ b/src/main/java/log/charter/gui/panes/songEdits/ChangeSongPitchPane.java
@@ -142,7 +142,7 @@ public class ChangeSongPitchPane extends RowedDialog {
 
 		LoadingDialog.doWithLoadingDialog(frame, 4, loadingDialog -> {
 			loadingDialog.setProgress(0, "Reading samples");
-			final AudioData audio = projectAudioHandler.getAudio();
+			final AudioData audio = projectAudioHandler.getMainAudio();
 			final int sampleSize = audio.format.getSampleSizeInBits() / 8;
 			final int channels = audio.format.getChannels();
 			final float[][] samples = FloatSamplesUtils.splitAudioFloat(audio.data, sampleSize, channels);

--- a/src/main/java/log/charter/gui/panes/songEdits/SetDefaultSilencePane.java
+++ b/src/main/java/log/charter/gui/panes/songEdits/SetDefaultSilencePane.java
@@ -51,7 +51,7 @@ public class SetDefaultSilencePane extends ParamsPane {
 	}
 
 	private void removeAudio(final double movement) {
-		final AudioData editedAudio = projectAudioHandler.getAudio().removeFromStart(movement / 1000.0);
+		final AudioData editedAudio = projectAudioHandler.getMainAudio().removeFromStart(movement / 1000.0);
 
 		projectAudioHandler.changeAudio(editedAudio);
 		projectAudioHandler.changeStemsOffset(-movement / 1000);
@@ -68,7 +68,7 @@ public class SetDefaultSilencePane extends ParamsPane {
 			return;
 		}
 
-		final AudioData songMusicData = projectAudioHandler.getAudio();
+		final AudioData songMusicData = projectAudioHandler.getMainAudio();
 		final AudioData silenceMusicData = AudioGenerator.generateSilence(movement / 1000.0,
 				songMusicData.format.getSampleRate(), songMusicData.format.getChannels(),
 				songMusicData.format.getSampleSizeInBits() / 8);

--- a/src/main/java/log/charter/gui/panes/songSettings/ArrangementSettingsPane.java
+++ b/src/main/java/log/charter/gui/panes/songSettings/ArrangementSettingsPane.java
@@ -1,6 +1,7 @@
 package log.charter.gui.panes.songSettings;
 
 import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static log.charter.data.ChordTemplateFingerSetter.setSuggestedFingers;
 import static log.charter.data.config.GraphicalConfig.inputSize;
 import static log.charter.data.song.configs.Tuning.getStringDistanceFromC0;
@@ -13,6 +14,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.swing.JCheckBox;
@@ -27,6 +29,9 @@ import log.charter.data.song.Arrangement.ArrangementSubtype;
 import log.charter.data.song.ChordTemplate;
 import log.charter.data.song.configs.Tuning;
 import log.charter.data.song.configs.Tuning.TuningType;
+import log.charter.data.song.notes.Chord;
+import log.charter.data.song.notes.ChordNote;
+import log.charter.data.song.notes.Note;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.components.containers.ParamsPane;
 import log.charter.gui.components.simple.CharterSelect;
@@ -387,14 +392,28 @@ public class ArrangementSettingsPane extends ParamsPane {
 
 			arrangement.levels.forEach(level -> {
 				level.sounds.forEach(sound -> {
-					if (!sound.isNote()) {
-						return;
-					}
-
-					if (sound.note().string >= tuning.strings()) {
-						sound.note().string = tuning.strings() - 1;
+					if (sound.isNote()) {
+						final Note note = sound.note();
+						if (note.string >= tuning.strings()) {
+							note.string = tuning.strings() - 1;
+						} else {
+							note.fret = min(InstrumentConfig.frets,
+									max(0, note.fret + fretsDifference[sound.note().string]));
+							if (note.slideTo != null) {
+								note.slideTo = min(InstrumentConfig.frets,
+										max(1, note.slideTo + fretsDifference[sound.note().string]));
+							}
+						}
 					} else {
-						sound.note().fret = max(0, sound.note().fret + fretsDifference[sound.note().string]);
+						final Chord chord = sound.chord();
+
+						for (final Entry<Integer, ChordNote> chordNote : chord.chordNotes.entrySet()) {
+							final ChordNote note = chordNote.getValue();
+							if (note.slideTo != null) {
+								note.slideTo = min(InstrumentConfig.frets,
+										max(1, note.slideTo + fretsDifference[chordNote.getKey()]));
+							}
+						}
 					}
 				});
 			});

--- a/src/main/java/log/charter/io/gp/GPFileImportOptions.java
+++ b/src/main/java/log/charter/io/gp/GPFileImportOptions.java
@@ -1,0 +1,16 @@
+package log.charter.io.gp;
+
+public class GPFileImportOptions {
+	public final boolean importTempoMap;
+	public final boolean generateFHP;
+	public final int slideInSize;
+	public final int slideOutSize;
+
+	public GPFileImportOptions(final boolean importTempoMap, final boolean generateFHP, final int slideInSize,
+			final int slideOutSize) {
+		this.importTempoMap = importTempoMap;
+		this.generateFHP = generateFHP;
+		this.slideInSize = slideInSize;
+		this.slideOutSize = slideOutSize;
+	}
+}

--- a/src/main/java/log/charter/io/gp/GPFileImportOptionsPane.java
+++ b/src/main/java/log/charter/io/gp/GPFileImportOptionsPane.java
@@ -1,0 +1,118 @@
+package log.charter.io.gp;
+
+import static log.charter.data.config.GraphicalConfig.inputSize;
+import static log.charter.gui.components.simple.TextInputWithValidation.generateForInt;
+
+import javax.swing.JCheckBox;
+
+import log.charter.data.config.Config;
+import log.charter.data.config.Localization.Label;
+import log.charter.data.config.values.GPConfig;
+import log.charter.data.config.values.InstrumentConfig;
+import log.charter.gui.CharterFrame;
+import log.charter.gui.components.containers.RowedDialog;
+import log.charter.gui.components.containers.SaverWithStatus;
+import log.charter.gui.components.simple.FieldWithLabel;
+import log.charter.gui.components.simple.FieldWithLabel.LabelPosition;
+import log.charter.gui.components.simple.TextInputWithValidation;
+import log.charter.gui.components.utils.RowedPosition;
+import log.charter.gui.components.utils.validators.IntValueValidator;
+
+public class GPFileImportOptionsPane extends RowedDialog {
+	private static final long serialVersionUID = -1952641299779494076L;
+
+	public static GPFileImportOptions getImportOptions(final CharterFrame frame,
+			final boolean importTempoMapDefaultValue) {
+		final GPFileImportOptionsPane optionsPane = new GPFileImportOptionsPane(frame, importTempoMapDefaultValue);
+
+		if (optionsPane.cancelled) {
+			return null;
+		}
+
+		final GPFileImportOptions importOptions = new GPFileImportOptions(optionsPane.importTempoMap(),
+				optionsPane.generateFHP(), optionsPane.slideInSize, optionsPane.slideOutSize);
+		GPConfig.generateFHP = importOptions.generateFHP;
+		GPConfig.slideInSize = importOptions.slideInSize;
+		GPConfig.slideOutSize = importOptions.slideOutSize;
+		Config.markChanged();
+
+		return importOptions;
+	}
+
+	private FieldWithLabel<JCheckBox> importTempoMapField;
+	private FieldWithLabel<JCheckBox> generateFHPField;
+	private FieldWithLabel<TextInputWithValidation> slideInSizeField;
+	private FieldWithLabel<TextInputWithValidation> slideOutSizeField;
+
+	private int slideInSize = GPConfig.slideInSize;
+	private int slideOutSize = GPConfig.slideOutSize;
+
+	private boolean cancelled = false;
+
+	public GPFileImportOptionsPane(final CharterFrame frame, final boolean importTempoMapDefaultValue) {
+		super(frame, Label.GP_FILE_IMPORT_OPTIONS);
+
+		final RowedPosition position = new RowedPosition(inputSize, panel.sizes);
+		addImportTempoMap(position, importTempoMapDefaultValue);
+		position.newRow();
+
+		addGenerateFHP(position);
+		position.newRow();
+
+		addSlideInSize(position);
+		position.newRow();
+		addSlideOutSize(position);
+		position.newRow();
+		position.newRow();
+
+		addDefaultFinish(position.y(), null, SaverWithStatus.defaultFor(this::cancel), true);
+	}
+
+	private void addImportTempoMap(final RowedPosition position, final boolean importTempoMapDefaultValue) {
+		final JCheckBox checkbox = new JCheckBox();
+		checkbox.setSelected(importTempoMapDefaultValue);
+
+		importTempoMapField = new FieldWithLabel<>(Label.IMPORT_TEMPO_MAP, inputSize * 7, inputSize, inputSize,
+				checkbox, LabelPosition.LEFT);
+		panel.add(importTempoMapField, position);
+	}
+
+	private void addGenerateFHP(final RowedPosition position) {
+		final JCheckBox checkbox = new JCheckBox();
+		checkbox.setSelected(GPConfig.generateFHP);
+
+		generateFHPField = new FieldWithLabel<>(Label.GENERATE_FHP, inputSize * 7, inputSize, inputSize, checkbox,
+				LabelPosition.LEFT);
+		panel.add(generateFHPField, position);
+	}
+
+	private void addSlideInSize(final RowedPosition position) {
+		final TextInputWithValidation input = generateForInt(slideInSize, inputSize * 5 / 2,
+				new IntValueValidator(1, InstrumentConfig.frets - 1), v -> slideInSize = v, false);
+
+		slideInSizeField = new FieldWithLabel<>(Label.SLIDE_IN_SIZE, inputSize * 7, inputSize, inputSize, input,
+				LabelPosition.LEFT);
+		panel.add(slideInSizeField, position);
+	}
+
+	private void addSlideOutSize(final RowedPosition position) {
+		final TextInputWithValidation input = generateForInt(slideOutSize, inputSize * 5 / 2,
+				new IntValueValidator(1, InstrumentConfig.frets - 1), v -> slideOutSize = v, false);
+
+		slideOutSizeField = new FieldWithLabel<>(Label.SLIDE_OUT_SIZE, inputSize * 7, inputSize, inputSize, input,
+				LabelPosition.LEFT);
+		panel.add(slideOutSizeField, position);
+	}
+
+	private void cancel() {
+		cancelled = true;
+	}
+
+	public boolean importTempoMap() {
+		return importTempoMapField.field.isSelected();
+	}
+
+	public boolean generateFHP() {
+		return generateFHPField.field.isSelected();
+	}
+}

--- a/src/main/java/log/charter/io/gp/gp5/GP5FileReader.java
+++ b/src/main/java/log/charter/io/gp/gp5/GP5FileReader.java
@@ -23,6 +23,7 @@ import log.charter.data.song.enums.BassPickingTechnique;
 import log.charter.data.song.enums.HOPO;
 import log.charter.data.song.enums.Harmonic;
 import log.charter.io.Logger;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.io.gp.gp5.data.Directions;
 import log.charter.io.gp.gp5.data.GP5File;
 import log.charter.io.gp.gp5.data.GPBar;
@@ -61,11 +62,11 @@ public class GP5FileReader {
 
 	private static final int percussionTrackFlag = 1 << 0;
 
-	public static GP5File importGPFile(final File file) {
+	public static GP5File importGPFile(final File file, final GPFileImportOptions importOptions) {
 		final ByteArrayInputStream inputStream = new ByteArrayInputStream(RW.readB(file));
 		final GP5FileReader reader = new GP5FileReader(inputStream);
 
-		return reader.readScore();
+		return reader.readScore(importOptions);
 	}
 
 	private final ByteArrayInputStream data;
@@ -84,7 +85,7 @@ public class GP5FileReader {
 		this.data = data;
 	}
 
-	private GP5File readScore() {
+	private GP5File readScore(final GPFileImportOptions importOptions) {
 		if (file != null) {
 			return file;
 		}

--- a/src/main/java/log/charter/io/gp/gp5/transformers/GP5ArrangementTransformer.java
+++ b/src/main/java/log/charter/io/gp/gp5/transformers/GP5ArrangementTransformer.java
@@ -10,6 +10,7 @@ import log.charter.data.song.BeatsMap;
 import log.charter.data.song.Level;
 import log.charter.data.song.configs.Tuning;
 import log.charter.data.song.configs.Tuning.TuningType;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.io.gp.gp5.GP5FractionalPosition;
 import log.charter.io.gp.gp5.data.GPBar;
 import log.charter.io.gp.gp5.data.GPBeat;
@@ -71,9 +72,9 @@ public class GP5ArrangementTransformer {
 	}
 
 	private static Level generateLevel(final BeatsMap beatsMap, final Arrangement arrangement,
-			final List<Integer> barsOrder, final List<GPBar> bars) {
+			final List<Integer> barsOrder, final List<GPBar> bars, final GPFileImportOptions importOptions) {
 		final Level level = new Level();
-		final GP5SoundsTransformer noteTransformer = new GP5SoundsTransformer(level, arrangement);
+		final GP5SoundsTransformer noteTransformer = new GP5SoundsTransformer(level, arrangement, importOptions);
 
 		final boolean[] wasHOPOStart = new boolean[InstrumentConfig.maxStrings];
 		final int[] hopoFrom = new int[InstrumentConfig.maxStrings];
@@ -102,14 +103,14 @@ public class GP5ArrangementTransformer {
 	}
 
 	public static Arrangement makeArrangement(final BeatsMap beatsMap, final List<Integer> barsOrder,
-			final GPTrackData trackData, final List<GPBar> bars) {
+			final GPFileImportOptions importOptions, final GPTrackData trackData, final List<GPBar> bars) {
 		final ArrangementType arrangementType = getGPArrangementType(trackData);
 		final Arrangement arrangement = new Arrangement(arrangementType);
 
 		arrangement.capo = trackData.capo;
 		arrangement.tuning = getTuningFromGPTuning(trackData.tuning, arrangement.capo,
 				arrangementType == ArrangementType.Bass);
-		arrangement.setLevel(0, generateLevel(beatsMap, arrangement, barsOrder, bars));
+		arrangement.setLevel(0, generateLevel(beatsMap, arrangement, barsOrder, bars, importOptions));
 
 		return arrangement;
 	}

--- a/src/main/java/log/charter/io/gp/gp5/transformers/GP5FileToSongChart.java
+++ b/src/main/java/log/charter/io/gp/gp5/transformers/GP5FileToSongChart.java
@@ -7,6 +7,7 @@ import java.util.List;
 import log.charter.data.song.Arrangement;
 import log.charter.data.song.BeatsMap;
 import log.charter.data.song.SongChart;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.io.gp.gp5.data.GP5File;
 import log.charter.io.gp.gp5.data.GPBar;
 import log.charter.io.gp.gp5.data.GPTrackData;
@@ -19,7 +20,7 @@ public class GP5FileToSongChart {
 	}
 
 	private static void addGP5Arrangements(final GP5File gp5File, final List<Integer> barsOrder,
-			final SongChart chart) {
+			final GPFileImportOptions importOptions, final SongChart chart) {
 		for (final int trackId : gp5File.trackBars.keySet()) {
 			final GPTrackData trackData = gp5File.tracks.get(trackId);
 			if (trackData.isPercussion) {
@@ -27,16 +28,18 @@ public class GP5FileToSongChart {
 			}
 
 			final List<GPBar> trackBars = gp5File.trackBars.get(trackId);
-			final Arrangement arrangement = makeArrangement(chart.beatsMap, barsOrder, trackData, trackBars);
+			final Arrangement arrangement = makeArrangement(chart.beatsMap, barsOrder, importOptions, trackData,
+					trackBars);
 			chart.arrangements.add(arrangement);
 		}
 	}
 
-	public static SongChart transform(final GP5File gp5File, final BeatsMap beatsMap, final List<Integer> barsOrder) {
+	public static SongChart transform(final GP5File gp5File, final BeatsMap beatsMap, final List<Integer> barsOrder,
+			final GPFileImportOptions importOptions) {
 		final SongChart chart = new SongChart(beatsMap);
 
 		addSongData(gp5File, chart);
-		addGP5Arrangements(gp5File, barsOrder, chart);
+		addGP5Arrangements(gp5File, barsOrder, importOptions, chart);
 
 		return chart;
 	}

--- a/src/main/java/log/charter/io/gp/gp5/transformers/GP5SoundsTransformer.java
+++ b/src/main/java/log/charter/io/gp/gp5/transformers/GP5SoundsTransformer.java
@@ -25,6 +25,7 @@ import log.charter.data.song.notes.ChordOrNote;
 import log.charter.data.song.notes.CommonNote;
 import log.charter.data.song.notes.Note;
 import log.charter.data.song.position.FractionalPosition;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.io.gp.gp5.GP5FractionalPosition;
 import log.charter.io.gp.gp5.data.GPBeat;
 import log.charter.io.gp.gp5.data.GPBend;
@@ -83,6 +84,7 @@ public class GP5SoundsTransformer {
 
 	private final Level level;
 	private final Arrangement arrangement;
+	private final GPFileImportOptions importOptions;
 
 	private ChordOrNote lastSound = null;
 	private ChordTemplate lastSoundTemplate = null;
@@ -90,9 +92,11 @@ public class GP5SoundsTransformer {
 
 	private boolean addSlideToLastSound = false;
 
-	public GP5SoundsTransformer(final Level level, final Arrangement arrangement) {
+	public GP5SoundsTransformer(final Level level, final Arrangement arrangement,
+			final GPFileImportOptions importOptions) {
 		this.level = level;
 		this.arrangement = arrangement;
+		this.importOptions = importOptions;
 	}
 
 	private boolean checkPreviousNoteLink(final GPNote gpNote) {
@@ -111,6 +115,7 @@ public class GP5SoundsTransformer {
 
 		if (addSlideToLastSound) {
 			lastSound.note().slideTo = gpNote.fret;
+			lastSound.note().unpitchedSlide = !lastSound.note().linkNext;
 			addSlideToLastSound = false;
 			linked = true;
 		}
@@ -189,11 +194,11 @@ public class GP5SoundsTransformer {
 
 		switch (effects.slideOut) {
 			case OUT_DOWN:
-				lastNote.slideTo = max(1, lastNote.fret - 5);
+				lastNote.slideTo = max(1, lastNote.fret - importOptions.slideOutSize);
 				lastNote.unpitchedSlide = true;
 				break;
 			case OUT_UP:
-				lastNote.slideTo = min(InstrumentConfig.frets, lastNote.fret + 5);
+				lastNote.slideTo = min(InstrumentConfig.frets, lastNote.fret + importOptions.slideOutSize);
 				lastNote.unpitchedSlide = true;
 				break;
 			case OUT_WITHOUT_PLUCK:
@@ -223,7 +228,7 @@ public class GP5SoundsTransformer {
 				afterNotes.add(slideInNoteFromAbove);
 				note.linkNext = true;
 				note.slideTo = note.fret;
-				note.fret = min(InstrumentConfig.frets, note.fret + 5);
+				note.fret = min(InstrumentConfig.frets, note.fret + importOptions.slideInSize);
 				break;
 			case IN_FROM_BELOW:
 				final Note slideInNoteFromBelow = new Note(note.position().add(new Fraction(1, 4)), note.string,
@@ -233,7 +238,7 @@ public class GP5SoundsTransformer {
 				afterNotes.add(slideInNoteFromBelow);
 				note.linkNext = true;
 				note.slideTo = note.fret;
-				note.fret = max(1, note.fret - 5);
+				note.fret = max(1, note.fret - importOptions.slideInSize);
 				break;
 			default:
 				break;

--- a/src/main/java/log/charter/io/gp/gp7/GP7PlusFileImporter.java
+++ b/src/main/java/log/charter/io/gp/gp7/GP7PlusFileImporter.java
@@ -1,6 +1,5 @@
 package log.charter.io.gp.gp7;
 
-import static log.charter.gui.components.utils.ComponentUtils.askYesNo;
 import static log.charter.gui.components.utils.ComponentUtils.showPopup;
 
 import java.io.File;
@@ -12,10 +11,11 @@ import log.charter.data.config.Localization.Label;
 import log.charter.data.song.BeatsMap;
 import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
-import log.charter.gui.components.utils.ComponentUtils.ConfirmAnswer;
 import log.charter.gui.menuHandlers.CharterMenuBar;
 import log.charter.gui.panes.imports.ArrangementImportOptions;
 import log.charter.io.Logger;
+import log.charter.io.gp.GPFileImportOptions;
+import log.charter.io.gp.GPFileImportOptionsPane;
 import log.charter.io.gp.gp7.data.GP7Asset;
 import log.charter.io.gp.gp7.data.GPIF;
 import log.charter.io.gp.gp7.transformers.GP7FileToSongChart;
@@ -74,18 +74,20 @@ public class GP7PlusFileImporter {
 			return;
 		}
 
-		final boolean importBeatMap = askYesNo(charterFrame, Label.GP_IMPORT_TEMPO_MAP,
-				Label.USE_TEMPO_MAP_FROM_IMPORT) == ConfirmAnswer.YES;
+		final GPFileImportOptions importOptions = GPFileImportOptionsPane.getImportOptions(charterFrame, false);
+		if (importOptions == null) {
+			return;
+		}
 
-		final SongChart temporaryChart = transformGPIFToSongChart(gpif, importBeatMap);
+		final SongChart temporaryChart = transformGPIFToSongChart(gpif, importOptions);
 
 		final List<String> trackNames = gpif.tracks.stream().map(t -> t.name).collect(Collectors.toList());
 		new ArrangementImportOptions(charterFrame, arrangementFixer, charterMenuBar, chartData, temporaryChart,
-				trackNames);
+				trackNames, importOptions);
 	}
 
-	public SongChart transformGPIFToSongChart(final GPIF gpif, final boolean importBeatMap) {
-		final BeatsMap beatsMap = gp7TempoReader.getTempoMap(gpif, importBeatMap);
-		return GP7FileToSongChart.transform(gpif, beatsMap);
+	public SongChart transformGPIFToSongChart(final GPIF gpif, final GPFileImportOptions importOptions) {
+		final BeatsMap beatsMap = gp7TempoReader.getTempoMap(gpif, importOptions.importTempoMap);
+		return GP7FileToSongChart.transform(gpif, beatsMap, importOptions);
 	}
 }

--- a/src/main/java/log/charter/io/gp/gp7/transformers/ChordCreator.java
+++ b/src/main/java/log/charter/io/gp/gp7/transformers/ChordCreator.java
@@ -24,6 +24,7 @@ import log.charter.data.song.notes.Note;
 import log.charter.data.song.notes.NoteInterface;
 import log.charter.data.song.position.FractionalPosition;
 import log.charter.data.song.position.time.Position;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.io.gp.gp7.data.GP7Beat;
 import log.charter.io.gp.gp7.data.GP7Note;
 import log.charter.io.gp.gp7.data.GP7Note.GP7HarmonicType;
@@ -35,6 +36,7 @@ import log.charter.util.data.Fraction;
 public class ChordCreator extends GP7NoteCreator {
 	private final Arrangement arrangement;
 	private final Map<Integer, NoteInterface> shouldSetSlideTo;
+	private final GPFileImportOptions importOptions;
 
 	private final GP7NotesWithPosition notes;
 	private final Chord chord = new Chord(-1);
@@ -48,10 +50,12 @@ public class ChordCreator extends GP7NoteCreator {
 	private ChordNote chordNote;
 
 	public ChordCreator(final ImmutableBeatsMap beats, final Arrangement arrangement,
-			final Map<Integer, NoteInterface> shouldSetSlideTo, final GP7NotesWithPosition notes) {
+			final Map<Integer, NoteInterface> shouldSetSlideTo, final GPFileImportOptions importOptions,
+			final GP7NotesWithPosition notes) {
 		super(beats);
 		this.arrangement = arrangement;
 		this.shouldSetSlideTo = shouldSetSlideTo;
+		this.importOptions = importOptions;
 
 		this.notes = notes;
 
@@ -184,7 +188,7 @@ public class ChordCreator extends GP7NoteCreator {
 
 		final Note preNote = new Note(notes.position, chord.position());
 		preNote.string = string();
-		preNote.fret = max(1, fret() - 2);
+		preNote.fret = max(1, fret() - importOptions.slideInSize);
 		preNote.linkNext = true;
 		preNote.slideTo = fret();
 		addPreSlideNote(preNote);
@@ -203,7 +207,7 @@ public class ChordCreator extends GP7NoteCreator {
 
 		final Note preNote = new Note(notes.position, chord.position());
 		preNote.string = string();
-		preNote.fret = min(InstrumentConfig.frets, fret() + 2);
+		preNote.fret = min(InstrumentConfig.frets, fret() + importOptions.slideInSize);
 		preNote.linkNext = true;
 		preNote.slideTo = fret();
 		addPreSlideNote(preNote);
@@ -229,11 +233,11 @@ public class ChordCreator extends GP7NoteCreator {
 				shouldSetSlideTo.put(string(), chordNote);
 				break;
 			case DOWN:
-				chordNote.slideTo = max(1, fret() - 5);
+				chordNote.slideTo = max(1, fret() - importOptions.slideOutSize);
 				chordNote.unpitchedSlide = true;
 				break;
 			case UP:
-				chordNote.slideTo = min(InstrumentConfig.frets, fret() + 5);
+				chordNote.slideTo = min(InstrumentConfig.frets, fret() + importOptions.slideOutSize);
 				chordNote.unpitchedSlide = true;
 				break;
 			default:

--- a/src/main/java/log/charter/io/gp/gp7/transformers/GP7FileToSongChart.java
+++ b/src/main/java/log/charter/io/gp/gp7/transformers/GP7FileToSongChart.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import log.charter.data.song.BeatsMap;
 import log.charter.data.song.SongChart;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.io.gp.gp7.data.GPIF;
 
 public class GP7FileToSongChart {
@@ -31,7 +32,8 @@ public class GP7FileToSongChart {
 		return true;
 	}
 
-	public static SongChart transform(final GPIF gpif, final BeatsMap beatsMap) {
+	public static SongChart transform(final GPIF gpif, final BeatsMap beatsMap,
+			final GPFileImportOptions importOptions) {
 		final SongChart chart = new SongChart(beatsMap);
 		setMetadata(chart, gpif);
 		final List<Track> tracks = new NotesPerTrackReader(beatsMap.immutable, gpif).getTracks();
@@ -41,7 +43,8 @@ public class GP7FileToSongChart {
 				continue;
 			}
 
-			chart.arrangements.add(GP7TrackToArrangementTransformer.transform(beatsMap.immutable, track));
+			chart.arrangements
+					.add(GP7TrackToArrangementTransformer.transform(beatsMap.immutable, track, importOptions));
 		}
 
 		return chart;

--- a/src/main/java/log/charter/io/gp/gp7/transformers/GP7TrackToArrangementTransformer.java
+++ b/src/main/java/log/charter/io/gp/gp7/transformers/GP7TrackToArrangementTransformer.java
@@ -14,23 +14,28 @@ import log.charter.data.song.configs.Tuning;
 import log.charter.data.song.configs.Tuning.TuningType;
 import log.charter.data.song.notes.ChordOrNote;
 import log.charter.data.song.notes.NoteInterface;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.io.rs.xml.song.ArrangementType;
 
 class GP7TrackToArrangementTransformer {
-	public static Arrangement transform(final ImmutableBeatsMap beats, final Track track) {
-		return new GP7TrackToArrangementTransformer(beats, track).transform();
+	public static Arrangement transform(final ImmutableBeatsMap beats, final Track track,
+			final GPFileImportOptions importOptions) {
+		return new GP7TrackToArrangementTransformer(beats, track, importOptions).transform();
 	}
 
 	private final ImmutableBeatsMap beats;
 	private final Track track;
+	private final GPFileImportOptions importOptions;
 
 	private final Arrangement arrangement = new Arrangement();
 
 	private final Map<Integer, NoteInterface> shouldSetSlideTo = new HashMap<>();
 
-	private GP7TrackToArrangementTransformer(final ImmutableBeatsMap beats, final Track track) {
+	private GP7TrackToArrangementTransformer(final ImmutableBeatsMap beats, final Track track,
+			final GPFileImportOptions importOptions) {
 		this.beats = beats;
 		this.track = track;
+		this.importOptions = importOptions;
 	}
 
 	private void setTuning() {
@@ -62,16 +67,18 @@ class GP7TrackToArrangementTransformer {
 			}
 
 			final List<ChordOrNote> sounds = switch (notes.notes.size()) {
-				case 1 -> new SingleNoteCreator(beats, arrangement, shouldSetSlideTo, notes)//
+				case 1 -> new SingleNoteCreator(beats, arrangement, shouldSetSlideTo, importOptions, notes)//
 						.generateNote().getCreatedSounds();
-				default -> new ChordCreator(beats, arrangement, shouldSetSlideTo, notes)//
+				default -> new ChordCreator(beats, arrangement, shouldSetSlideTo, importOptions, notes)//
 						.setChordValues().getCreatedSounds();
 			};
 
 			level.sounds.addAll(sounds);
 		}
 
-		createFHPs(beats, arrangement.chordTemplates, level.sounds, level.fhps);
+		if (importOptions.generateFHP) {
+			createFHPs(beats, arrangement.chordTemplates, level.sounds, level.fhps);
+		}
 	}
 
 	private Arrangement transform() {

--- a/src/main/java/log/charter/io/gp/gp7/transformers/SingleNoteCreator.java
+++ b/src/main/java/log/charter/io/gp/gp7/transformers/SingleNoteCreator.java
@@ -22,6 +22,7 @@ import log.charter.data.song.notes.Note;
 import log.charter.data.song.notes.NoteInterface;
 import log.charter.data.song.position.FractionalPosition;
 import log.charter.data.song.position.time.Position;
+import log.charter.io.gp.GPFileImportOptions;
 import log.charter.io.gp.gp7.data.GP7Beat;
 import log.charter.io.gp.gp7.data.GP7Note;
 import log.charter.io.gp.gp7.data.GP7Note.GP7HarmonicType;
@@ -33,6 +34,7 @@ import log.charter.util.data.Fraction;
 public class SingleNoteCreator extends GP7NoteCreator {
 	private final Arrangement arrangement;
 	private final Map<Integer, NoteInterface> shouldSetSlideTo;
+	private final GPFileImportOptions importOptions;
 
 	private final FractionalPosition position;
 	private final GP7Beat gp7Beat;
@@ -42,10 +44,12 @@ public class SingleNoteCreator extends GP7NoteCreator {
 	private Note note = new Note();
 
 	public SingleNoteCreator(final ImmutableBeatsMap beats, final Arrangement arrangement,
-			final Map<Integer, NoteInterface> shouldSetSlideTo, final GP7NotesWithPosition notes) {
+			final Map<Integer, NoteInterface> shouldSetSlideTo, final GPFileImportOptions importOptions,
+			final GP7NotesWithPosition notes) {
 		super(beats);
 		this.arrangement = arrangement;
 		this.shouldSetSlideTo = shouldSetSlideTo;
+		this.importOptions = importOptions;
 
 		position = notes.position;
 
@@ -144,7 +148,7 @@ public class SingleNoteCreator extends GP7NoteCreator {
 		note.position(position.add(toAdd));
 		final Note preNote = new Note(position, note.position());
 		preNote.string = note.string;
-		preNote.fret = max(1, note.fret - 2);
+		preNote.fret = max(1, note.fret - importOptions.slideInSize);
 		preNote.linkNext = true;
 		preNote.slideTo = note.fret;
 		notesCreated.add(0, preNote);
@@ -160,7 +164,7 @@ public class SingleNoteCreator extends GP7NoteCreator {
 		note.position(position.add(toAdd));
 		final Note preNote = new Note(position, note.position());
 		preNote.string = note.string;
-		preNote.fret = min(InstrumentConfig.frets, note.fret + 2);
+		preNote.fret = min(InstrumentConfig.frets, note.fret + importOptions.slideInSize);
 		preNote.linkNext = true;
 		preNote.slideTo = note.fret;
 		notesCreated.add(0, preNote);
@@ -186,11 +190,11 @@ public class SingleNoteCreator extends GP7NoteCreator {
 				shouldSetSlideTo.put(note.string, note);
 				break;
 			case DOWN:
-				note.slideTo = max(1, note.fret - 5);
+				note.slideTo = max(1, note.fret - importOptions.slideOutSize);
 				note.unpitchedSlide = true;
 				break;
 			case UP:
-				note.slideTo = min(InstrumentConfig.frets, note.fret + 5);
+				note.slideTo = min(InstrumentConfig.frets, note.fret + importOptions.slideOutSize);
 				note.unpitchedSlide = true;
 				break;
 			default:

--- a/src/main/java/log/charter/io/rs/xml/song/ArrangementLevel.java
+++ b/src/main/java/log/charter/io/rs/xml/song/ArrangementLevel.java
@@ -8,9 +8,9 @@ import java.util.List;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
-import log.charter.data.song.FHP;
 import log.charter.data.song.BeatsMap.ImmutableBeatsMap;
 import log.charter.data.song.ChordTemplate;
+import log.charter.data.song.FHP;
 import log.charter.data.song.HandShape;
 import log.charter.data.song.Level;
 import log.charter.data.song.notes.Chord;
@@ -78,7 +78,9 @@ public class ArrangementLevel {
 			final ArrangementChord arrangementChord = new ArrangementChord(beats, chord, chordTemplate, forceAddNotes);
 
 			if (chord.splitIntoNotes) {
-				arrangementChord.chordNotes.stream().map(ArrangementNote::new).forEach(notes.list::add);
+				if (!chord.forceNoNotes) {
+					arrangementChord.chordNotes.stream().map(ArrangementNote::new).forEach(notes.list::add);
+				}
 			} else {
 				chords.list.add(arrangementChord);
 			}

--- a/src/main/java/log/charter/services/data/files/ExistingProjectImporter.java
+++ b/src/main/java/log/charter/services/data/files/ExistingProjectImporter.java
@@ -31,6 +31,7 @@ public class ExistingProjectImporter {
 	private ChartTimeHandler chartTimeHandler;
 	private ChordTemplatesEditorTab chordTemplatesEditorTab;
 	private ProjectAudioHandler projectAudioHandler;
+	private SongFileHandler songFileHandler;
 	private TextTab textTab;
 
 	private ChartProject loadProjectFile(final File projectFileChosen) {
@@ -115,6 +116,10 @@ public class ExistingProjectImporter {
 	}
 
 	public void open(final String path) {
+		if (!songFileHandler.askToSaveChanged()) {
+			return;
+		}
+
 		doWithLoadingDialog(charterFrame, 3, dialog -> openInternal(dialog, path), "open " + path);
 	}
 }

--- a/src/main/java/log/charter/services/data/files/GP5FileImporter.java
+++ b/src/main/java/log/charter/services/data/files/GP5FileImporter.java
@@ -1,6 +1,5 @@
 package log.charter.services.data.files;
 
-import static log.charter.gui.components.utils.ComponentUtils.askYesNo;
 import static log.charter.gui.components.utils.ComponentUtils.showPopup;
 import static log.charter.io.gp.gp5.transformers.GP5BarOrderExtractor.getBarsOrder;
 import static log.charter.io.gp.gp5.transformers.GP5FileTempoMapExtractor.getTempoMap;
@@ -14,10 +13,11 @@ import log.charter.data.config.Localization.Label;
 import log.charter.data.song.BeatsMap;
 import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
-import log.charter.gui.components.utils.ComponentUtils.ConfirmAnswer;
 import log.charter.gui.menuHandlers.CharterMenuBar;
 import log.charter.gui.panes.imports.ArrangementImportOptions;
 import log.charter.io.Logger;
+import log.charter.io.gp.GPFileImportOptions;
+import log.charter.io.gp.GPFileImportOptionsPane;
 import log.charter.io.gp.gp5.GP5FileReader;
 import log.charter.io.gp.gp5.data.GP5File;
 import log.charter.io.gp.gp5.transformers.GP5FileToSongChart;
@@ -31,15 +31,16 @@ public class GP5FileImporter {
 	private CharterMenuBar charterMenuBar;
 	private ChartTimeHandler chartTimeHandler;
 
-	private boolean askUserAboutUsingImportTempoMap() {
-		return askYesNo(charterFrame, Label.GP_IMPORT_TEMPO_MAP, Label.USE_TEMPO_MAP_FROM_IMPORT) == ConfirmAnswer.YES;
-	}
-
 	public void importGP5File(final File file) {
 		try {
+			final GPFileImportOptions importOptions = GPFileImportOptionsPane.getImportOptions(charterFrame, false);
+			if (importOptions == null) {
+				return;
+			}
+
 			final GP5File gp5File;
 			try {
-				gp5File = GP5FileReader.importGPFile(file);
+				gp5File = GP5FileReader.importGPFile(file, importOptions);
 			} catch (final Exception e) {
 				Logger.error("Couldn't import gp5 file " + file.getAbsolutePath(), e);
 				showPopup(charterFrame, Label.COULDNT_IMPORT_GP5);
@@ -51,18 +52,17 @@ public class GP5FileImporter {
 			final double startPosition = chartData.songChart.beatsMap.beats.get(0).position();
 			final BeatsMap beatsMap;
 
-			final boolean useImportTempoMap = askUserAboutUsingImportTempoMap();
-			if (useImportTempoMap) {
+			if (importOptions.importTempoMap) {
 				beatsMap = getTempoMap(gp5File, startPosition, chartTimeHandler.maxTime(), barsOrder);
 			} else {
 				beatsMap = chartData.songChart.beatsMap;
 			}
 
-			final SongChart temporaryChart = GP5FileToSongChart.transform(gp5File, beatsMap, barsOrder);
+			final SongChart temporaryChart = GP5FileToSongChart.transform(gp5File, beatsMap, barsOrder, importOptions);
 
 			final List<String> trackNames = gp5File.tracks.stream().map(t -> t.trackName).collect(Collectors.toList());
 			new ArrangementImportOptions(charterFrame, arrangementFixer, charterMenuBar, chartData, temporaryChart,
-					trackNames);
+					trackNames, importOptions);
 		} catch (final Exception e) {
 			Logger.error("Couldn't import gp5 file", e);
 		}

--- a/src/main/java/log/charter/services/data/files/newProject/NewEmptyProjectCreator.java
+++ b/src/main/java/log/charter/services/data/files/newProject/NewEmptyProjectCreator.java
@@ -32,7 +32,7 @@ public class NewEmptyProjectCreator {
 		final AudioFileMetadata metadata = AudioFileMetadata.readMetadata(songFile);
 
 		final String defaultFolderName = newProjectService.generateFolderName(songFile, metadata);
-		final File projectFolder = newProjectService.chooseSongFolder(songFile.getParent(), defaultFolderName);
+		final File projectFolder = newProjectService.chooseSongFolder(songFile.getParentFile(), defaultFolderName);
 		if (projectFolder == null) {
 			return;
 		}

--- a/src/main/java/log/charter/services/data/files/newProject/NewProjectFromGP7Creator.java
+++ b/src/main/java/log/charter/services/data/files/newProject/NewProjectFromGP7Creator.java
@@ -133,7 +133,7 @@ public class NewProjectFromGP7Creator {
 		addGPIFMetadata(metadata, gpif);
 
 		final String defaultFolderName = newProjectService.generateFolderName(songFile.file, metadata);
-		final File songFolder = newProjectService.chooseSongFolder(songFile.file.getParent(), defaultFolderName);
+		final File songFolder = newProjectService.chooseSongFolder(songFile.file.getParentFile(), defaultFolderName);
 		if (songFolder == null) {
 			songFile.deleteTempFile();
 			return;

--- a/src/main/java/log/charter/services/data/files/newProject/NewProjectFromGP7Creator.java
+++ b/src/main/java/log/charter/services/data/files/newProject/NewProjectFromGP7Creator.java
@@ -9,6 +9,8 @@ import log.charter.data.config.values.PathsConfig;
 import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
 import log.charter.io.Logger;
+import log.charter.io.gp.GPFileImportOptions;
+import log.charter.io.gp.GPFileImportOptionsPane;
 import log.charter.io.gp.gp7.GP7PlusFileImporter;
 import log.charter.io.gp.gp7.data.GPIF;
 import log.charter.services.data.files.SongFileHandler;
@@ -145,7 +147,12 @@ public class NewProjectFromGP7Creator {
 			return;
 		}
 
-		final SongChart songChart = gp7PlusFileImporter.transformGPIFToSongChart(gpif, true);
+		final GPFileImportOptions importOptions = GPFileImportOptionsPane.getImportOptions(charterFrame, true);
+		if (importOptions == null) {
+			return;
+		}
+
+		final SongChart songChart = gp7PlusFileImporter.transformGPIFToSongChart(gpif, importOptions);
 		newProjectService.fillMetadata(songChart, songFile.file, metadata);
 		newProjectService.setDataForNewProject(songFolder, songChart, musicData);
 	}

--- a/src/main/java/log/charter/services/data/files/newProject/NewProjectFromRSXMLCreator.java
+++ b/src/main/java/log/charter/services/data/files/newProject/NewProjectFromRSXMLCreator.java
@@ -1,6 +1,7 @@
 package log.charter.services.data.files.newProject;
 
 import static log.charter.gui.components.utils.ComponentUtils.showPopup;
+import static log.charter.services.data.files.newProject.NewProjectService.generateDefaultChartFolderName;
 
 import java.io.File;
 
@@ -45,13 +46,7 @@ public class NewProjectFromRSXMLCreator {
 		return musicData;
 	}
 
-	private SongChart readSongArrangement(final File songFile) {
-		final File arrangementFile = FileChooseUtils.chooseFile(charterFrame, songFile.getParent(),
-				new String[] { ".xml" }, new String[] { Label.RS_ARRANGEMENT_FILE.label() });
-		if (arrangementFile == null) {
-			return null;
-		}
-
+	private SongChart readSongArrangement(final File songFile, final File arrangementFile) {
 		final LoadingDialog loadingDialog = new LoadingDialog(charterFrame, 1);
 		loadingDialog.setProgress(0, Label.LOADING_ARRANGEMENTS.label());
 		final SongArrangement songArrangement = SongArrangementXStreamHandler.readSong(arrangementFile);
@@ -72,12 +67,23 @@ public class NewProjectFromRSXMLCreator {
 			return;
 		}
 
-		final SongChart songChart = readSongArrangement(songFile);
+		final File arrangementFile = FileChooseUtils.chooseFile(charterFrame, songFile.getParent(),
+				new String[] { ".xml" }, new String[] { Label.RS_ARRANGEMENT_FILE.label() });
+		if (arrangementFile == null) {
+			return;
+		}
+
+		final SongChart songChart = readSongArrangement(songFile, arrangementFile);
 		if (songChart == null) {
 			return;
 		}
 
-		newProjectService.setDataForNewProject(songFile.getParentFile(), songChart, musicData);
+		final String defaultChartFolderName = generateDefaultChartFolderName(songFile.getName(), songChart.artistName(),
+				songChart.title());
+		final File projectFolder = newProjectService.chooseSongFolder(songFile.getParentFile(), defaultChartFolderName,
+				arrangementFile.getParentFile());
+
+		newProjectService.setDataForNewProject(projectFolder, songChart, musicData);
 		modeManager.setArrangement(0);
 		chartTimeHandler.nextTime(0);
 	}

--- a/src/main/java/log/charter/services/data/files/newProject/NewProjectFromRSXMLCreator.java
+++ b/src/main/java/log/charter/services/data/files/newProject/NewProjectFromRSXMLCreator.java
@@ -15,6 +15,7 @@ import log.charter.io.rs.xml.RSXMLToSongChart;
 import log.charter.io.rs.xml.song.SongArrangement;
 import log.charter.io.rs.xml.song.SongArrangementXStreamHandler;
 import log.charter.services.data.ChartTimeHandler;
+import log.charter.services.data.files.SongFileHandler;
 import log.charter.services.editModes.EditMode;
 import log.charter.services.editModes.ModeManager;
 import log.charter.sound.data.AudioData;
@@ -26,6 +27,7 @@ public class NewProjectFromRSXMLCreator {
 	private ChartTimeHandler chartTimeHandler;
 	private ModeManager modeManager;
 	private NewProjectService newProjectService;
+	private SongFileHandler songFileHandler;
 
 	private File chooseSongFile() {
 		final String fileChooseDir = modeManager.getMode() == EditMode.EMPTY ? PathsConfig.songsPath : chartData.path;
@@ -57,6 +59,10 @@ public class NewProjectFromRSXMLCreator {
 	}
 
 	public void createSongWithImportFromArrangementXML() {
+		if (!songFileHandler.askToSaveChanged()) {
+			return;
+		}
+
 		final File songFile = chooseSongFile();
 		if (songFile == null) {
 			return;

--- a/src/main/java/log/charter/services/data/files/newProject/NewProjectService.java
+++ b/src/main/java/log/charter/services/data/files/newProject/NewProjectService.java
@@ -8,12 +8,14 @@ import java.io.File;
 
 import log.charter.data.ChartData;
 import log.charter.data.config.Localization.Label;
-import log.charter.data.config.values.PathsConfig;
 import log.charter.data.song.SongChart;
 import log.charter.gui.CharterFrame;
 import log.charter.gui.components.containers.SongFolderSelectPane;
+import log.charter.gui.components.containers.SongFolderSelectPane.FolderSelectedType;
 import log.charter.gui.components.tabs.TextTab;
 import log.charter.gui.components.tabs.chordEditor.ChordTemplatesEditorTab;
+import log.charter.gui.components.utils.ComponentUtils;
+import log.charter.gui.components.utils.ComponentUtils.ConfirmAnswer;
 import log.charter.services.audio.AudioHandler;
 import log.charter.services.data.ProjectAudioHandler;
 import log.charter.services.data.files.SongFileHandler;
@@ -21,6 +23,21 @@ import log.charter.sound.audioFormats.AudioFileMetadata;
 import log.charter.sound.data.AudioData;
 
 public class NewProjectService {
+	public static String generateDefaultChartFolderName(final String audioFileName, final String artist,
+			final String title) {
+		String defaultFolderName;
+		if (artist.isBlank() && title.isBlank()) {
+			final String songFileName = audioFileName;
+			defaultFolderName = songFileName.substring(0, songFileName.lastIndexOf('.'));
+		} else {
+			defaultFolderName = "%s - %s".formatted(artist.isBlank() ? "unknown artist" : artist, //
+					title.isBlank() ? "unknown title" : title);
+		}
+		defaultFolderName = cleanFileName(defaultFolderName);
+
+		return defaultFolderName;
+	}
+
 	private AudioHandler audioHandler;
 	private ChartData chartData;
 	private CharterFrame charterFrame;
@@ -30,51 +47,46 @@ public class NewProjectService {
 	private TextTab textTab;
 
 	public String generateFolderName(final File songFile, final AudioFileMetadata metadata) {
-		String defaultFolderName;
-		if (metadata.artist.isBlank() && metadata.title.isBlank()) {
-			final String songFileName = songFile.getName();
-			defaultFolderName = songFileName.substring(0, songFileName.lastIndexOf('.'));
-		} else {
-			defaultFolderName = "%s - %s".formatted(metadata.artist.isBlank() ? "unknown artist" : metadata.artist, //
-					metadata.title.isBlank() ? "unknown title" : metadata.title);
-		}
-		defaultFolderName = cleanFileName(defaultFolderName);
-
-		return defaultFolderName;
+		return generateDefaultChartFolderName(songFile.getName(), metadata.artist, metadata.title);
 	}
 
-	public File chooseSongFolder(final String audioFileDirectory, final String defaultFolderName) {
-		File songFolder = null;
+	public File chooseSongFolder(final File audioFileDirectory, final String defaultFolderName) {
+		return chooseSongFolder(audioFileDirectory, defaultFolderName, null);
+	}
 
-		while (songFolder == null) {
-			final SongFolderSelectPane songFolderSelectPane = new SongFolderSelectPane(charterFrame,
-					PathsConfig.songsPath, audioFileDirectory, defaultFolderName);
+	public File chooseSongFolder(final File audioFileDirectory, final String defaultFolderName,
+			final File xmlFileDirectory) {
+		File folder = null;
 
-			if (songFolderSelectPane.isAudioFolderChosen()) {
-				return new File(audioFileDirectory);
-			}
+		while (folder == null) {
+			final FolderSelectedType defaultType = xmlFileDirectory != null ? FolderSelectedType.XML_FILE
+					: FolderSelectedType.CHARTS_DIR;
+			final SongFolderSelectPane songFolderSelectPane = new SongFolderSelectPane(charterFrame, audioFileDirectory,
+					defaultFolderName, null, xmlFileDirectory, defaultType);
 
-			String folderName = songFolderSelectPane.getFolderName();
-			if (folderName == null || folderName.isBlank()) {
+			final FolderSelectedType folderType = songFolderSelectPane.getFolderType();
+			if (folderType == null) {
 				return null;
 			}
-			folderName = cleanFileName(folderName);
 
-			songFolder = new File(PathsConfig.songsPath, folderName);
+			folder = songFolderSelectPane.getFolder();
 
-			if (songFolder.exists()) {
-				songFolder = null;
-				showPopup(charterFrame, Label.FOLDER_EXISTS_CHOOSE_DIFFERENT);
-				continue;
-			}
-			if (!songFolder.mkdir()) {
-				songFolder = null;
-				showPopup(charterFrame, Label.COULDNT_CREATE_FOLDER_CHOOSE_DIFFERENT);
-				continue;
+			if (folderType == FolderSelectedType.CHARTS_DIR) {
+				if (folder.exists()) {
+					final ConfirmAnswer answer = ComponentUtils.askYesNo(charterFrame, Label.FOLDER_EXISTS,
+							Label.FOLDER_EXISTS_MSG);
+					if (answer == ConfirmAnswer.YES) {
+						break;
+					}
+				} else if (!folder.mkdir()) {
+					folder = null;
+					showPopup(charterFrame, Label.COULDNT_CREATE_FOLDER_CHOOSE_DIFFERENT);
+					continue;
+				}
 			}
 		}
 
-		return songFolder;
+		return folder;
 	}
 
 	public void fillMetadata(final SongChart songChart, final File songFile, final AudioFileMetadata metadata) {

--- a/src/main/java/log/charter/services/data/fixers/ArrangementFixer.java
+++ b/src/main/java/log/charter/services/data/fixers/ArrangementFixer.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -17,6 +18,7 @@ import log.charter.data.ChartData;
 import log.charter.data.song.Arrangement;
 import log.charter.data.song.BeatsMap.ImmutableBeatsMap;
 import log.charter.data.song.BendValue;
+import log.charter.data.song.ChordTemplate;
 import log.charter.data.song.EventPoint;
 import log.charter.data.song.FHP;
 import log.charter.data.song.HandShape;
@@ -503,6 +505,28 @@ public class ArrangementFixer {
 		}
 	}
 
+	private void fixCapoFrets(final Arrangement arrangement, final Level level) {
+		final int capo = arrangement.capo;
+
+		for (final ChordTemplate template : arrangement.chordTemplates) {
+			for (final Entry<Integer, Integer> entry : template.frets.entrySet()) {
+				if (entry.getValue() <= capo) {
+					template.frets.put(entry.getKey(), 0);
+				}
+			}
+		}
+
+		for (final ChordOrNote sound : level.sounds) {
+			if (!sound.isNote()) {
+				continue;
+			}
+
+			if (sound.note().fret <= capo) {
+				sound.note().fret = 0;
+			}
+		}
+	}
+
 	private void fixLevel(final Arrangement arrangement, final Level level) {
 		level.fhps.sort(IConstantFractionalPosition::compareTo);
 		level.sounds.sort(IConstantFractionalPosition::compareTo);
@@ -524,6 +548,7 @@ public class ArrangementFixer {
 		fixLengths(level.handShapes);
 		fixSlides(level.sounds);
 		addMissingBends(level.sounds);
+		fixCapoFrets(arrangement, level);
 	}
 
 	public void fixArrangements() {

--- a/src/main/java/log/charter/services/data/validation/GuitarSoundsValidator.java
+++ b/src/main/java/log/charter/services/data/validation/GuitarSoundsValidator.java
@@ -1,14 +1,17 @@
 package log.charter.services.data.validation;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import log.charter.data.config.Localization.Label;
 import log.charter.data.song.Arrangement;
 import log.charter.data.song.ChordTemplate;
+import log.charter.data.song.EventPoint;
 import log.charter.data.song.FHP;
 import log.charter.data.song.HandShape;
 import log.charter.data.song.Level;
+import log.charter.data.song.SectionType;
 import log.charter.data.song.enums.HOPO;
 import log.charter.data.song.notes.Chord;
 import log.charter.data.song.notes.ChordNote;
@@ -280,7 +283,26 @@ public class GuitarSoundsValidator {
 			}
 		}
 
+		private void validateSoundGoingOverPhraseChange(final List<EventPoint> phrases, final int id,
+				final ChordOrNote sound) {
+			final EventPoint nextPhrase = CollectionUtils.firstAfter(phrases, sound).find();
+			if (nextPhrase == null) {
+				errorsTab.addError(generateError(Label.SOUND_PAST_LAST_PHRASE, id));
+				return;
+			}
+
+			final int comparison = sound.endPosition().compareTo(nextPhrase);
+			if (comparison < 0 || ((nextPhrase.section == SectionType.NO_GUITAR || "END".equals(nextPhrase.phrase))
+					&& comparison == 0)) {
+				return;
+			}
+
+			errorsTab.addError(generateError(Label.SOUND_SPLIT_BY_PHRASE, id));
+		}
+
 		private void validateSounds() {
+			final List<EventPoint> phrases = arrangement.getFilteredEventPoints(EventPoint::hasPhrase);
+
 			for (int i = 0; i < level.sounds.size(); i++) {
 				final ChordOrNote sound = level.sounds.get(i);
 
@@ -293,6 +315,7 @@ public class GuitarSoundsValidator {
 				validateChordTail(i, sound);
 				validateTremoloVibratoTail(i, sound);
 				validateChordWithSplitAndOnlyBox(i, sound);
+				validateSoundGoingOverPhraseChange(phrases, i, sound);
 			}
 		}
 

--- a/src/main/java/log/charter/services/data/validation/GuitarSoundsValidator.java
+++ b/src/main/java/log/charter/services/data/validation/GuitarSoundsValidator.java
@@ -269,6 +269,17 @@ public class GuitarSoundsValidator {
 			}
 		}
 
+		private void validateChordWithSplitAndOnlyBox(final int id, final ChordOrNote sound) {
+			if (!sound.isChord()) {
+				return;
+			}
+
+			final Chord chord = sound.chord();
+			if (chord.forceNoNotes && chord.splitIntoNotes) {
+				errorsTab.addError(generateError(Label.CHORD_WITH_SPLIT_AND_ONLY_BOX, id));
+			}
+		}
+
 		private void validateSounds() {
 			for (int i = 0; i < level.sounds.size(); i++) {
 				final ChordOrNote sound = level.sounds.get(i);
@@ -281,6 +292,7 @@ public class GuitarSoundsValidator {
 				validateNoteFHP(i, sound);
 				validateChordTail(i, sound);
 				validateTremoloVibratoTail(i, sound);
+				validateChordWithSplitAndOnlyBox(i, sound);
 			}
 		}
 

--- a/src/main/java/log/charter/services/data/validation/GuitarSoundsValidator.java
+++ b/src/main/java/log/charter/services/data/validation/GuitarSoundsValidator.java
@@ -259,6 +259,16 @@ public class GuitarSoundsValidator {
 			}
 		}
 
+		private void validateTremoloVibratoTail(final int id, final ChordOrNote sound) {
+			final boolean hasTremoloOrVibratoWithoutTail = sound.noteInterfaces()//
+					.anyMatch(n -> (n.vibrato() || n.tremolo())//
+							&& n.endPosition().equals(n.position()));
+
+			if (hasTremoloOrVibratoWithoutTail) {
+				errorsTab.addError(generateError(Label.SOUND_WITH_TREMOLO_OR_VIBRATO_WITHOUT_TAIL, id));
+			}
+		}
+
 		private void validateSounds() {
 			for (int i = 0; i < level.sounds.size(); i++) {
 				final ChordOrNote sound = level.sounds.get(i);
@@ -270,6 +280,7 @@ public class GuitarSoundsValidator {
 				validateCorrectHOPO(i, sound);
 				validateNoteFHP(i, sound);
 				validateChordTail(i, sound);
+				validateTremoloVibratoTail(i, sound);
 			}
 		}
 

--- a/src/main/java/log/charter/services/data/validation/PhrasesValidator.java
+++ b/src/main/java/log/charter/services/data/validation/PhrasesValidator.java
@@ -10,6 +10,7 @@ import log.charter.data.song.Arrangement;
 import log.charter.data.song.EventPoint;
 import log.charter.data.song.HandShape;
 import log.charter.data.song.Level;
+import log.charter.data.song.SectionType;
 import log.charter.data.song.position.FractionalPosition;
 import log.charter.gui.components.tabs.errorsTab.ChartError;
 import log.charter.gui.components.tabs.errorsTab.ChartPositionGenerator;
@@ -84,6 +85,11 @@ public class PhrasesValidator {
 
 			final HandShape handShape = CollectionUtils.lastBefore(level.handShapes, eventPoint).find();
 			if (handShape == null || handShape.endPosition().compareTo(eventPoint) < 0) {
+				continue;
+			}
+			final int comparison = handShape.endPosition().compareTo(eventPoint);
+			if (comparison < 0 || ((eventPoint.section == SectionType.NO_GUITAR || "END".equals(eventPoint.phrase))
+					&& comparison == 0)) {
 				continue;
 			}
 

--- a/src/main/java/log/charter/services/mouseAndKeyboard/MouseHandler.java
+++ b/src/main/java/log/charter/services/mouseAndKeyboard/MouseHandler.java
@@ -233,10 +233,13 @@ public class MouseHandler implements MouseListener, MouseMotionListener, MouseWh
 
 	private <T extends IVirtualPosition> void dragPositions(final PositionType type,
 			final MouseButtonPressReleaseData clickData, final List<T> allPositions) {
+		if (!clickData.pressHighlight.existingPosition) {
+			return;
+		}
+
 		List<Selection<T>> selectedPositions = selectionManager.<T>accessor(type).getSelected();
 
-		if (clickData.pressHighlight.existingPosition//
-				&& !contains(selectedPositions, s -> s.id == clickData.pressHighlight.id)) {
+		if (!contains(selectedPositions, s -> s.id == clickData.pressHighlight.id)) {
 			selectionManager.clear();
 			selectionManager.addSelection(type, clickData.pressHighlight.id);
 			selectedPositions = selectionManager.<T>accessor(type)//
@@ -262,11 +265,14 @@ public class MouseHandler implements MouseListener, MouseMotionListener, MouseWh
 
 	private <T extends IVirtualPositionWithEnd> void dragPositionsWithLength(final PositionType type,
 			final MouseButtonPressReleaseData clickData, final List<T> allPositions) {
+		if (!clickData.pressHighlight.existingPosition) {
+			return;
+		}
+
 		List<Selection<T>> selectedPositions = selectionManager.<T>accessor(clickData.pressHighlight.type)//
 				.getSelected();
 
-		if (clickData.pressHighlight.existingPosition//
-				&& !contains(selectedPositions, s -> s.id == clickData.pressHighlight.id)) {
+		if (!contains(selectedPositions, s -> s.id == clickData.pressHighlight.id)) {
 			selectionManager.clear();
 			selectionManager.addSelection(clickData.pressHighlight.type, clickData.pressHighlight.id);
 			selectedPositions = selectionManager.<T>accessor(clickData.pressHighlight.type)//
@@ -293,11 +299,14 @@ public class MouseHandler implements MouseListener, MouseMotionListener, MouseWh
 	}
 
 	private void dragSounds(final MouseButtonPressReleaseData clickData, final List<ChordOrNote> allPositions) {
+		if (!clickData.pressHighlight.existingPosition) {
+			return;
+		}
+
 		List<Selection<ChordOrNote>> selectedPositions = selectionManager
 				.<ChordOrNote>accessor(clickData.pressHighlight.type).getSelected();
 
-		if (clickData.pressHighlight.existingPosition//
-				&& !contains(selectedPositions, s -> s.id == clickData.pressHighlight.id)) {
+		if (!contains(selectedPositions, s -> s.id == clickData.pressHighlight.id)) {
 			selectionManager.clear();
 			selectionManager.addSelection(clickData.pressHighlight.type, clickData.pressHighlight.id);
 			selectedPositions = selectionManager.<ChordOrNote>accessor(clickData.pressHighlight.type)//


### PR DESCRIPTION
- Changed new project folder select to allow for any folder to be selected, also added selecting folder when project is made based on RS XML
- Changed dragging to only work when an item was pressed (can't drag by pressing empty space now)
- Added asking for confirmation to open last project if there are unsaved changes
- Added GP import settings panel, values of FHP generation, slide in size and slide out size are remembered
- Fixed saving of `Show note names` value
- Fixed `Unpitched slide` flag
- Added validation for notes that have tremolo or vibrato and no sustain
- Added validation and fixed saving when chord has both `Split` and `Only box` flags
- Added validation for notes going overnext phrase or linked to notes in next phrase
- Added changing slide values on changing tuning
- Added fixing frets below capo to 0
- Fixed stem audio being changed and set as main audio if silence is added while stem is selected, now adds silence properly to and saves main audio
- Removed some FHPs being created during gp import even if flag to create them is unchecked